### PR TITLE
[Feat] SchoolCalendar 화면 구현

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,7 @@
 import './App.scss';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Header } from './components';
-import { MyPage, MainNotice } from './pages';
+import { MyPage, MainNotice, SchoolCalendar } from './pages';
 
 function App() {
   return (
@@ -9,7 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Header />}>
           <Route index element={<MainNotice />} />
-          <Route path="schoolCalendar" element={<h1>schoolCalendar</h1>} />
+          <Route path="schoolCalendar" element={<SchoolCalendar />} />
           <Route path="myPage" element={<MyPage />} />
           <Route path="login" element={<h1>login</h1>} />
           <Route path="*" element={<h1>Not Found</h1>} />

--- a/frontend/src/components/EventModal/EventModal.jsx
+++ b/frontend/src/components/EventModal/EventModal.jsx
@@ -1,20 +1,21 @@
 // 새 이벤트를 추가하는 모달 또는 폼 컴포넌트
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './EventModal.module.scss';
 import closeIcon from '../../assets/icons/close.svg';
 import { ConfigProvider, DatePicker } from 'antd';
 import { colors } from '../../constants/eventColors';
 import classNames from 'classnames';
+import dayjs from "dayjs";
 
 const { RangePicker } = DatePicker;
 
-export const EventModal = ({ modalTitle, saveEvent, closeModal }) => {
-  const [title, setTitle] = useState('');
-  const [start, setStart] = useState('');
-  const [end, setEnd] = useState('');
-  const [memo, setMemo] = useState('');
-  const [url, setUrl] = useState('');
-  const [color, setColor] = useState('');
+export const EventModal = ({ modalTitle, saveEvent, closeModal, prevData }) => {
+  const [title, setTitle] = useState(prevData && prevData.title !== '' ? prevData.title : '');
+  const [start, setStart] = useState(prevData && prevData.start !== '' ? prevData.start : '');
+  const [end, setEnd] = useState(prevData && prevData.end !== '' ? prevData.end : '');
+  const [memo, setMemo] = useState(prevData && prevData.memo !== '' ? prevData.memo : '');
+  const [url, setUrl] = useState(prevData && prevData.url !== '' ? prevData.url : '');
+  const [color, setColor] = useState(prevData && prevData.color !== '' ? prevData.color : '');
   const [isMouseDownInside, setIsMouseDownInside] = useState(false);
 
   const handleMouseDownInside = () => {
@@ -111,7 +112,9 @@ export const EventModal = ({ modalTitle, saveEvent, closeModal }) => {
             <label className={styles.label}>기간 </label>
             <div className={styles.wrapper}>
               <RangePicker
+                defaultValue={prevData ? [dayjs(start), dayjs(end)] : null}
                 onChange={dates => {
+                  console.log(dates)
                   if (dates.length === 2) {
                     // 첫 번째 날짜의 시, 분, 초를 0으로 설정
                     const startDate = new Date(dates[0].$d);

--- a/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
+++ b/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useRef, useState } from "react";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+
+import EventList from "./components/EventList";
+import EventDetail from "./components/EventDetail";
+import styles from './SchoolCalendar.module.scss';
+import { EventModal } from "../../components/EventModal/EventModal";
+
+const SchoolCalendar = () => {
+  const calendarRef = useRef(null);
+  const [events, setEvents] = useState([]);
+  const [listedEvents, setListedEvents] = useState([]);
+  const [eventTitle, setEventTitle] = useState('');
+  const [eventDateStart, setEventDateStart] = useState('');
+  const [eventDateEnd, setEventDateEnd] = useState('');
+  const [eventMemo, setEventMemo] = useState('');
+  const [eventUrl, setEventUrl] = useState('');
+  const [eventColor, setEventColor] = useState('');
+  const [showModal, setShowModal] = useState(false);
+
+  //localStorage에서 불러오는 거로 추후에는 백 연동 코드로 변경 예정
+  useEffect(() => {
+    const data = localStorage.getItem("sample");
+    const redata = data ? JSON.parse(data) : '';
+    setEvents(redata);
+    setListedEvents(redata);
+  }, []);
+
+  const handleEventClick = (eventData, jsEvent) => {
+    // jsEvent가 있으면 기본 동작 방지 (FullCalendar 이벤트에서만 적용)
+    if (jsEvent) {
+      jsEvent.preventDefault();
+    }
+
+    // eventData의 구조에 따라 필요한 정보를 추출
+    const { title, url, extendedProps, backgroundColor, start, end } = eventData;
+    setEventTitle(title);
+    setEventUrl(url);
+    setEventMemo(extendedProps ? extendedProps.memo : '');
+    setEventColor(backgroundColor);
+    setEventDateStart(start);
+    setEventDateEnd(end);
+    console.log(title);
+
+  };
+
+
+  // 내 일정 추가(추후에는 DB에 보내기)
+  const saveEvent = (eventData) => {
+    if (eventData.end) {
+      const endDate = new Date(eventData.end);
+      endDate.setHours(23, 59, 59, 999); // 날짜의 시간을 23:59:59.999로 설정
+      eventData.end = endDate;
+    }
+
+    localStorage.setItem("akakakak", JSON.stringify(eventData));
+    setShowModal(false);
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.leftWrapper}>
+        <EventList listedEvents={listedEvents} handleEventClick={handleEventClick} />
+        <EventDetail
+          eventTitle={eventTitle}
+          eventDateStart={eventDateStart}
+          eventDateEnd={eventDateEnd}
+          eventMemo={eventMemo}
+          eventUrl={eventUrl}
+          eventColor={eventColor}
+          onOpen={() => setShowModal(!showModal)}
+        />
+      </div>
+      <FullCalendar
+        ref={calendarRef}
+        initialView="dayGridMonth"
+        events={events}
+        plugins={[dayGridPlugin, interactionPlugin]}
+        headerToolbar={{
+          left: '',
+          center: 'prev title next',
+          right: '',
+        }}
+        titleFormat={({ date }) => `${date.year}. ${date.month + 1}`}
+        // eventColor={'#f5a986'}
+        editable={true}
+        // selectable={true}
+        displayEventTime={false}
+        eventClick={clickInfo => handleEventClick(clickInfo.event, clickInfo.jsEvent)}
+        nextDayThreshold={'00:00:00'}
+      />
+      {
+        showModal && <EventModal
+          modalTitle={'내 일정으로 추가'}
+          prevData={{
+            title: eventTitle,
+            start: eventDateStart,
+            end: eventDateEnd,
+            color: eventColor,
+          }}
+          saveEvent={saveEvent}
+          closeModal={() => setShowModal(!showModal)}
+        />
+      }
+    </div>
+  );
+}
+
+export default SchoolCalendar;

--- a/frontend/src/pages/SchoolCalendar/SchoolCalendar.module.scss
+++ b/frontend/src/pages/SchoolCalendar/SchoolCalendar.module.scss
@@ -1,0 +1,169 @@
+.container {
+  display: flex;
+  gap: 2.4rem;
+  justify-content: flex-end;
+  width: calc(100% - 2.4rem * 2);
+  height: calc(100vh - 2.4rem * 2 - 6.8rem);
+  margin: 2.4rem;
+  padding: 3.2rem;
+  border-radius: 0.7rem;
+  border: 1px solid rgba(229, 231, 235, 0.8);
+}
+
+.leftWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 2rem;
+  width: 25%;
+  height: 100%;
+}
+
+.eventList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 5.1rem;
+  flex-grow: 1;
+  overflow-y: auto;
+
+  // WebKit 기반 브라우저를 위한 스크롤바 스타일
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--gray-200); // gray-200 색상
+    border-radius: 10px;
+  }
+
+  // Firefox를 위한 스크롤바 스타일
+  @supports (scrollbar-width: thin) {
+    scrollbar-width: thin;
+    scrollbar-color: var(--gray-200) transparent;
+  }
+}
+
+.eventListRow {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+}
+
+.eventText {
+  color: var(--gray-800, #1f2937);
+  font-family: Noto Sans KR;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.eventDday {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 50px;
+  height: 100%;
+  color: var(--gray-400, #9ca3af);
+  text-align: right;
+  font-family: Noto Sans KR;
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: 0.12rem;
+  margin-left: auto;
+  margin-right: 1rem;
+}
+
+.eventWrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 23.6rem;
+  border-radius: 0.7rem;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  padding: 1.8rem;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.titleWrapper {
+  display: flex;
+  align-items: center;
+  // height:
+  gap: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.eventColor {
+  width: 1.2rem;
+  height: 100%;
+  background: var(--gray-200, #e5e7eb);
+}
+
+.title {
+  color: var(--gray-800, #1f2937);
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+.row {
+  display: flex;
+  margin: 0.3rem 0;
+}
+
+.subtitleWrapper {
+  min-width: 35px;
+}
+
+.subtitle {
+  color: var(--gray-600, #4b5563);
+  // font-family: Noto Sans KR;
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+
+.content {
+  color: var(--gray-600, #4b5563);
+  // font-family: Noto Sans KR;
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  word-wrap: break-word;
+  word-break: break-all;
+}
+
+.button {
+  width: fit-content;
+  justify-self: flex-end;
+  align-self: flex-end;
+  display: inline-flex;
+  padding: 0.8rem 1.3rem;
+  align-items: center;
+  gap: 0.8rem;
+  border-radius: 0.7rem;
+  border: 1px solid var(--gray-200, #e5e7eb);
+  color: var(--gray-900, #111827);
+  font-family: Noto Sans KR;
+  background-color: white;
+  font-size: 1.3rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  margin-top: auto;
+}
+
+.plusIcon {
+  margin: 0 0.5rem 0 0;
+  color: var(--gray-700);
+}

--- a/frontend/src/pages/SchoolCalendar/components/EventDetail.jsx
+++ b/frontend/src/pages/SchoolCalendar/components/EventDetail.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styles from '../SchoolCalendar.module.scss';
+import classNames from 'classnames';
+import { formatDate } from '../../../utils/dateUtils';
+import { AiOutlinePlus } from "react-icons/ai";
+
+const EventDetail = ({ eventTitle, eventDateStart, eventDateEnd, eventMemo, eventUrl, eventColor, onOpen }) => {
+  return (
+    <div className={classNames(styles.eventWrapper, eventTitle === '' && styles.invisible)}>
+      <div className={styles.titleWrapper}>
+        <div className={styles.eventColor} style={{ backgroundColor: eventColor }} />
+        <div className={styles.title}>{eventTitle}</div>
+      </div>
+      <div className={styles.row}>
+        <div className={styles.subtitleWrapper}>
+          <div className={styles.subtitle}>기간</div>
+        </div>
+        <div className={styles.content}>
+          {eventDateStart === '' && eventDateEnd === '' ? (
+            '없음'
+          ) : (
+            <>
+              {formatDate(eventDateStart)} ~ {eventDateEnd ? formatDate(eventDateEnd) : formatDate(eventDateStart)}
+            </>
+          )}
+        </div>
+      </div>
+      <button className={styles.button} onClick={() => onOpen()}>
+        <AiOutlinePlus className={styles.plusIcon} />
+        내 일정 추가
+      </button>
+    </div>
+  );
+};
+
+export default EventDetail;

--- a/frontend/src/pages/SchoolCalendar/components/EventList.jsx
+++ b/frontend/src/pages/SchoolCalendar/components/EventList.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styles from '../SchoolCalendar.module.scss';
+import { calculateDDay } from '../../../utils/dateUtils';
+
+const EventList = ({ listedEvents, handleEventClick }) => {
+  return (
+    <div className={styles.eventList}>
+      {listedEvents.map(event => (
+        <div key={event.defId} className={styles.eventListRow} onClick={() => handleEventClick(event)}>
+          <div className={styles.eventColor} style={{ backgroundColor: event.backgroundColor }}></div>
+          <div className={styles.eventText}>{event.title}</div>
+          <div className={styles.eventDday}>{calculateDDay(event.end)}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default EventList;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,3 +1,3 @@
-
 export { default as MainNotice } from "./MainNotice/MainNotice";
 export { default as MyPage } from './MyPage/MyPage';
+export { default as SchoolCalendar} from './SchoolCalendar/SchoolCalendar';


### PR DESCRIPTION
## 관련 이슈
- #12 
- #5 

## 구현/변경 사항
- 기존 마이페이지 UI와 동일하게 구현
- 내 일정 추가 버튼 클릭 시, 일정 제목 및 기간이 일정 모달에 반영되도록 EventModal 코드 수정
```javascript
<EventModal
          modalTitle={'내 일정으로 추가'}
          prevData={{ // 새 일정 등록 클릭 시에는 필요 없는 속성으로 작성하지 않아도 되며, 들어갈 객체는 페이지 별로 달라져도 됨
            title: eventTitle,
            start: eventDateStart,
            end: eventDateEnd,
            color: eventColor,
          }}
          saveEvent={saveEvent}
          closeModal={() => setShowModal(!showModal)}
        />
```

- EventModal에서는 다음과 같이 이전 정보를 받음
```javascript
export const EventModal = ({ modalTitle, saveEvent, closeModal, prevData }) => {
  // prevData가 안 들어오면 ''으로 초기화
  const [title, setTitle] = useState(prevData && prevData.title !== '' ? prevData.title : '');
  const [start, setStart] = useState(prevData && prevData.start !== '' ? prevData.start : '');
  const [end, setEnd] = useState(prevData && prevData.end !== '' ? prevData.end : '');
  const [memo, setMemo] = useState(prevData && prevData.memo !== '' ? prevData.memo : '');
  const [url, setUrl] = useState(prevData && prevData.url !== '' ? prevData.url : '');
  const [color, setColor] = useState(prevData && prevData.color !== '' ? prevData.color : '');
```

## 스크린샷
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/127061457/76afe666-0c46-455a-b74b-bb9c3699fa88)