### PR TITLE
[Feat] 학사일정 제목과 주관부서 분리하여 DB 저장

### DIFF
--- a/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
@@ -1,6 +1,6 @@
 package com.ziio.backend.controller;
 
-import com.ziio.backend.crawling.CrawlerManager;
+import com.ziio.backend.crawler.CrawlerManager;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;

--- a/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
@@ -1,6 +1,6 @@
 package com.ziio.backend.controller;
 
-import com.ziio.backend.crawling.CrawlerManager;
+import com.ziio.backend.crawler.CrawlerManager;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;

--- a/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
@@ -1,5 +1,5 @@
 // 학사일정 웹사이트
-package com.ziio.backend.crawling;
+package com.ziio.backend.crawler;
 
 import com.ziio.backend.entity.Academic;
 import com.ziio.backend.service.AcademicService;

--- a/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
@@ -38,21 +38,24 @@ public class AcademicCalendarWebsiteCrawler {
 
         for (Element tr : boardList.select("tr")) { // tr 태그 조회
             String date = "";
-            String titleAndHostDepartment = "";
+            String title = "";
+            String host_department = "";
             int index = 0;
             for (Element td : tr.select("td")) { // td 태그 조회
                 if (index == 0) {
                     date = td.text(); // 기간
                     index++;
                 } else if (index == 1) {
-                    titleAndHostDepartment = td.text(); // 제목 및 주관 부서
+                    title = td.ownText(); // 제목
+                    host_department = td.select("p").text(); // 주관 부서
                     break;
                 }
             }
             // DB 저장 로직
             Academic academic = new Academic();
             academic.setDate(date);
-            academic.setTitleAndHostDepartment(titleAndHostDepartment);
+            academic.setTitle(title);
+            academic.setHost_department(host_department);
             academicService.save(academic);
         }
     }

--- a/backend/src/main/java/com/ziio/backend/crawler/CollegeAndDepartmentWebsiteCrawler.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/CollegeAndDepartmentWebsiteCrawler.java
@@ -1,5 +1,5 @@
-// 동국대학교 메인 웹사이트
-package com.ziio.backend.crawling;
+// 단과대 및 학과 웹사이트
+package com.ziio.backend.crawler;
 
 import com.ziio.backend.constants.CrawlingInfos;
 import com.ziio.backend.entity.Category;
@@ -17,35 +17,37 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MainWebsiteCrawler {
+public class CollegeAndDepartmentWebsiteCrawler {
     private final NoticeService noticeService;
     private final CategoryService categoryService;
-
     @Autowired
-    public MainWebsiteCrawler(NoticeService noticeService, CategoryService categoryService) {
+    public CollegeAndDepartmentWebsiteCrawler(NoticeService noticeService, CategoryService categoryService) {
         this.noticeService = noticeService;
         this.categoryService = categoryService;
     }
     // 크롤링 실행
     public void crawl() {
-        String[][] mainAllInfos = CrawlingInfos.MAIN_ALL_INFOS;
+        String[][] mainAllInfos = CrawlingInfos.COLLEGE_AND_DEPARTMENT_ALL_INFOS;
         for (String[] eachInfo : mainAllInfos) {
-            getNoticeList(eachInfo[0], eachInfo[1], eachInfo[2], Integer.parseInt(eachInfo[3]));
-            }
+            getNoticeList(eachInfo[0], eachInfo[1], eachInfo[2], eachInfo[3], Integer.parseInt(eachInfo[4]));
         }
+    }
+
     // 카테고리 별로 크롤링
-    private void getNoticeList(String categoryID, String categoryName, String noticeKind, int pageLimit) {
-        List<String> url_Infos = new ArrayList<>(); List<String> title_Infos = new ArrayList<>();
-        List<String> date_Infos = new ArrayList<>(); List<String> author_Infos = new ArrayList<>();
+    private void getNoticeList(String categoryID, String categoryName, String noticeKind, String noticeNum, int pageLimit) {
+        List<String> url_Infos = new ArrayList<>();
+        List<String> title_Infos = new ArrayList<>();
+        List<String> date_Infos = new ArrayList<>();
+        List<String> author_Infos = new ArrayList<>();
         int topFixed = 0; // 상단 고정 공지 개수
 
         for (int pageNum = 1; pageNum <= pageLimit; pageNum++) {
-            String URL = "https://www.dongguk.edu/article/" + noticeKind + "/list?pageIndex=" + pageNum + "&"; // 크롤링할 웹사이트 URL
+            String URL = "https://" + noticeKind + ".dongguk.edu/article/notice" + noticeNum + "/list?pageIndex=" + pageNum; // 크롤링할 웹사이트 URL
             Connection conn = Jsoup.connect(URL); // Jsoup 연결 객체 생성
             try {
                 Document document = conn.get(); // HTML 구조를 불러와 할당
-                getNoticeURL(document, noticeKind, url_Infos, pageNum, topFixed);              // URL
-                topFixed = getNoticeTitle(document, title_Infos, pageNum, topFixed);           // 제목
+                topFixed = getNoticeURL(document, noticeKind, noticeNum, url_Infos, pageNum, topFixed); // URL
+                getNoticeTitle(document, title_Infos, pageNum, topFixed);                      // 제목
                 getNoticeDateAndAuthor(document, date_Infos, author_Infos, pageNum, topFixed); // 게시일, 글 작성자
             } catch (IOException ignored) {
             }
@@ -69,65 +71,69 @@ public class MainWebsiteCrawler {
     }
 
     // 1. URL
-    private void getNoticeURL(Document document, String noticeKind, List<String> url_Infos, int pageNum, int topFixed) {
-        Elements boardList = document.select("div.board_list ul"); // class명이 board_list인 ul 태그 조회
+    private int getNoticeURL(Document document, String noticeKind, String noticeNum, List<String> url_Infos, int pageNum, int topFixed) {
+        Elements boardList = document.select("table.board tbody"); // table태그 class명 board => tbody 태그 조회
         int index = 0; // 현 페이지에서 몇 번째 공지인지
 
-        for (Element li : boardList.select("li")) { // li 태그 조회
+        for (Element tr : boardList.select("tr")) { // tr 태그 조회
             if (pageNum > 1 && topFixed > index) { // 중복 제거
                 index++;
                 continue;
             }
-            String details = li.select("a").attr("onclick");
-            String detailURL = "https://www.dongguk.edu/article/" + noticeKind + "/detail/" + details.substring(9,details.length()-2);
-            url_Infos.add(detailURL);
-            index++;
-        }
-    }
-
-    // 2. 제목
-    private int getNoticeTitle(Document document, List<String> title_Infos, int pageNum, int topFixed) {
-        Elements boardList = document.select("div.board_list ul"); // class명이 board_list인 ul 태그 조회
-        int index = 0; // 현 페이지에서 몇 번째 공지인지
-
-        for (Element top : boardList.select("li div.top")) { // li 태그 => div 클래스 top 태그 조회
-            if (pageNum > 1 && topFixed > index) { // 중복 제거
-                index++;
-                continue;
-            }
-            // 2. 공지사항 제목 파싱
-            String title = top.select("p.tit").text();
-            // 상단 고정 공지 개수 파악
-            if (title.startsWith("공지")) {
+            String detailURL = "";
+            // 상단 고정 공지인 경우
+            if (tr.select("td.td_tit a").attr("href").equals("#none")) {
+                String details = tr.select("td.td_tit a").attr("onclick"); // td태그 class명 td_tit
+                detailURL = "https://" + noticeKind + ".dongguk.edu/article/notice" + noticeNum + "/detail/" + details.substring(9, details.length() - 2);
                 topFixed++;
+            } else if (tr.select("td.td_tit a").attr("href").startsWith("/")){
+                String href = tr.select("td.td_tit a").attr("href");
+                detailURL = "https://" + noticeKind + ".dongguk.edu" + href;
+            } else {
+                break;
             }
-            title_Infos.add(title);
+            url_Infos.add(detailURL);
             index++;
         }
         return topFixed;
     }
 
-    // 3, 4. 게시일, 글 작성자
-    private void getNoticeDateAndAuthor(Document document, List<String> date_Infos, List<String> author_Infos, int pageNum, int topFixed) {
-        Elements boardList = document.select("div.board_list ul"); // class명이 board_list인 ul 태그에 조회
+    // 2. 제목
+    private void getNoticeTitle(Document document, List<String> title_Infos, int pageNum, int topFixed) {
+        Elements boardList = document.select("table.board tbody"); // table태그 class명 board => tbody 태그 조회
         int index = 0; // 현 페이지에서 몇 번째 공지인지
 
-        for (Element li : boardList.select("li div.top")) { // li 태그 => div 클래스 top 태그 조회
+        for (Element tr : boardList.select("tr")) { // tr 태그 조회
+            if (pageNum > 1 && topFixed > index) { // 중복 제거
+                index++;
+                continue;
+            }
+            // 2. 공지사항 제목 파싱
+            String title = tr.select("td.td_tit a").text(); // td 태그 class명 td_tit
+            title_Infos.add(title);
+            index++;
+        }
+    }
+
+    // 3, 4. 게시일, 글 작성자
+    private void getNoticeDateAndAuthor(Document document, List<String> date_Infos, List<String> author_Infos, int pageNum, int topFixed) {
+        Elements boardList = document.select("table.board tbody"); // table태그 class명 board => tbody 태그 조회
+        int index = 0; // 현 페이지에서 몇 번째 공지인지
+
+        for (Element tr : boardList.select("tr")) { // tr 태그 조회
             if (pageNum > 1 && topFixed > index) { // 중복 제거
                 index++;
                 continue;
             }
             int cnt = 0; // 게시일과 저자를 구분하기 위함
-            for (Element span : li.select("div.info span")) { // div 클래스 info 태그 => span 태그 조회
-                if (cnt == 0) { // 3. 게시일
-                    date_Infos.add(span.text());
-                    cnt++;
-                } else if (cnt == 1) { // 4. 글 작성자
-                    author_Infos.add(span.text());
-                    cnt++;
-                } else {
+            for (Element td : tr.select("td")) { // td 태그 조회
+                if (cnt == 2) { // 3. 저자
+                    author_Infos.add(td.text());
+                } else if (cnt == 3) { // 4. 게시일
+                    date_Infos.add(td.text());
                     break;
                 }
+                cnt++;
             }
             index++;
         }

--- a/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
@@ -32,9 +32,4 @@ public class CrawlerManager {
     public void runAcademicCrawlers() {
         academicCalendarWebsiteCrawler.crawl();
     }
-
-    private void processData() {
-        // 크롤링된 데이터 처리 코드 작성
-        // 각 크롤러 클래스의 결과를 병합하거나 원하는 형태로 가공할 수 있습니다.
-    }
 }

--- a/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
@@ -1,4 +1,4 @@
-package com.ziio.backend.crawling;
+package com.ziio.backend.crawler;
 
 import com.ziio.backend.service.AcademicService;
 import com.ziio.backend.service.CategoryService;

--- a/backend/src/main/java/com/ziio/backend/crawler/EtcWebsiteCrawler.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/EtcWebsiteCrawler.java
@@ -1,5 +1,5 @@
 // 동국대학교 메인 웹사이트
-package com.ziio.backend.crawling;
+package com.ziio.backend.crawler;
 
 import com.ziio.backend.constants.CrawlingInfos;
 import com.ziio.backend.entity.Category;

--- a/backend/src/main/java/com/ziio/backend/crawler/MainWebsiteCrawler.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/MainWebsiteCrawler.java
@@ -1,5 +1,5 @@
-// 단과대 및 학과 웹사이트
-package com.ziio.backend.crawling;
+// 동국대학교 메인 웹사이트
+package com.ziio.backend.crawler;
 
 import com.ziio.backend.constants.CrawlingInfos;
 import com.ziio.backend.entity.Category;
@@ -17,37 +17,35 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CollegeAndDepartmentWebsiteCrawler {
+public class MainWebsiteCrawler {
     private final NoticeService noticeService;
     private final CategoryService categoryService;
+
     @Autowired
-    public CollegeAndDepartmentWebsiteCrawler(NoticeService noticeService, CategoryService categoryService) {
+    public MainWebsiteCrawler(NoticeService noticeService, CategoryService categoryService) {
         this.noticeService = noticeService;
         this.categoryService = categoryService;
     }
     // 크롤링 실행
     public void crawl() {
-        String[][] mainAllInfos = CrawlingInfos.COLLEGE_AND_DEPARTMENT_ALL_INFOS;
+        String[][] mainAllInfos = CrawlingInfos.MAIN_ALL_INFOS;
         for (String[] eachInfo : mainAllInfos) {
-            getNoticeList(eachInfo[0], eachInfo[1], eachInfo[2], eachInfo[3], Integer.parseInt(eachInfo[4]));
+            getNoticeList(eachInfo[0], eachInfo[1], eachInfo[2], Integer.parseInt(eachInfo[3]));
+            }
         }
-    }
-
     // 카테고리 별로 크롤링
-    private void getNoticeList(String categoryID, String categoryName, String noticeKind, String noticeNum, int pageLimit) {
-        List<String> url_Infos = new ArrayList<>();
-        List<String> title_Infos = new ArrayList<>();
-        List<String> date_Infos = new ArrayList<>();
-        List<String> author_Infos = new ArrayList<>();
+    private void getNoticeList(String categoryID, String categoryName, String noticeKind, int pageLimit) {
+        List<String> url_Infos = new ArrayList<>(); List<String> title_Infos = new ArrayList<>();
+        List<String> date_Infos = new ArrayList<>(); List<String> author_Infos = new ArrayList<>();
         int topFixed = 0; // 상단 고정 공지 개수
 
         for (int pageNum = 1; pageNum <= pageLimit; pageNum++) {
-            String URL = "https://" + noticeKind + ".dongguk.edu/article/notice" + noticeNum + "/list?pageIndex=" + pageNum; // 크롤링할 웹사이트 URL
+            String URL = "https://www.dongguk.edu/article/" + noticeKind + "/list?pageIndex=" + pageNum + "&"; // 크롤링할 웹사이트 URL
             Connection conn = Jsoup.connect(URL); // Jsoup 연결 객체 생성
             try {
                 Document document = conn.get(); // HTML 구조를 불러와 할당
-                topFixed = getNoticeURL(document, noticeKind, noticeNum, url_Infos, pageNum, topFixed); // URL
-                getNoticeTitle(document, title_Infos, pageNum, topFixed);                      // 제목
+                getNoticeURL(document, noticeKind, url_Infos, pageNum, topFixed);              // URL
+                topFixed = getNoticeTitle(document, title_Infos, pageNum, topFixed);           // 제목
                 getNoticeDateAndAuthor(document, date_Infos, author_Infos, pageNum, topFixed); // 게시일, 글 작성자
             } catch (IOException ignored) {
             }
@@ -71,69 +69,65 @@ public class CollegeAndDepartmentWebsiteCrawler {
     }
 
     // 1. URL
-    private int getNoticeURL(Document document, String noticeKind, String noticeNum, List<String> url_Infos, int pageNum, int topFixed) {
-        Elements boardList = document.select("table.board tbody"); // table태그 class명 board => tbody 태그 조회
+    private void getNoticeURL(Document document, String noticeKind, List<String> url_Infos, int pageNum, int topFixed) {
+        Elements boardList = document.select("div.board_list ul"); // class명이 board_list인 ul 태그 조회
         int index = 0; // 현 페이지에서 몇 번째 공지인지
 
-        for (Element tr : boardList.select("tr")) { // tr 태그 조회
+        for (Element li : boardList.select("li")) { // li 태그 조회
             if (pageNum > 1 && topFixed > index) { // 중복 제거
                 index++;
                 continue;
             }
-            String detailURL = "";
-            // 상단 고정 공지인 경우
-            if (tr.select("td.td_tit a").attr("href").equals("#none")) {
-                String details = tr.select("td.td_tit a").attr("onclick"); // td태그 class명 td_tit
-                detailURL = "https://" + noticeKind + ".dongguk.edu/article/notice" + noticeNum + "/detail/" + details.substring(9, details.length() - 2);
-                topFixed++;
-            } else if (tr.select("td.td_tit a").attr("href").startsWith("/")){
-                String href = tr.select("td.td_tit a").attr("href");
-                detailURL = "https://" + noticeKind + ".dongguk.edu" + href;
-            } else {
-                break;
-            }
+            String details = li.select("a").attr("onclick");
+            String detailURL = "https://www.dongguk.edu/article/" + noticeKind + "/detail/" + details.substring(9,details.length()-2);
             url_Infos.add(detailURL);
             index++;
         }
-        return topFixed;
     }
 
     // 2. 제목
-    private void getNoticeTitle(Document document, List<String> title_Infos, int pageNum, int topFixed) {
-        Elements boardList = document.select("table.board tbody"); // table태그 class명 board => tbody 태그 조회
+    private int getNoticeTitle(Document document, List<String> title_Infos, int pageNum, int topFixed) {
+        Elements boardList = document.select("div.board_list ul"); // class명이 board_list인 ul 태그 조회
         int index = 0; // 현 페이지에서 몇 번째 공지인지
 
-        for (Element tr : boardList.select("tr")) { // tr 태그 조회
+        for (Element top : boardList.select("li div.top")) { // li 태그 => div 클래스 top 태그 조회
             if (pageNum > 1 && topFixed > index) { // 중복 제거
                 index++;
                 continue;
             }
             // 2. 공지사항 제목 파싱
-            String title = tr.select("td.td_tit a").text(); // td 태그 class명 td_tit
+            String title = top.select("p.tit").text();
+            // 상단 고정 공지 개수 파악
+            if (title.startsWith("공지")) {
+                topFixed++;
+            }
             title_Infos.add(title);
             index++;
         }
+        return topFixed;
     }
 
     // 3, 4. 게시일, 글 작성자
     private void getNoticeDateAndAuthor(Document document, List<String> date_Infos, List<String> author_Infos, int pageNum, int topFixed) {
-        Elements boardList = document.select("table.board tbody"); // table태그 class명 board => tbody 태그 조회
+        Elements boardList = document.select("div.board_list ul"); // class명이 board_list인 ul 태그에 조회
         int index = 0; // 현 페이지에서 몇 번째 공지인지
 
-        for (Element tr : boardList.select("tr")) { // tr 태그 조회
+        for (Element li : boardList.select("li div.top")) { // li 태그 => div 클래스 top 태그 조회
             if (pageNum > 1 && topFixed > index) { // 중복 제거
                 index++;
                 continue;
             }
             int cnt = 0; // 게시일과 저자를 구분하기 위함
-            for (Element td : tr.select("td")) { // td 태그 조회
-                if (cnt == 2) { // 3. 저자
-                    author_Infos.add(td.text());
-                } else if (cnt == 3) { // 4. 게시일
-                    date_Infos.add(td.text());
+            for (Element span : li.select("div.info span")) { // div 클래스 info 태그 => span 태그 조회
+                if (cnt == 0) { // 3. 게시일
+                    date_Infos.add(span.text());
+                    cnt++;
+                } else if (cnt == 1) { // 4. 글 작성자
+                    author_Infos.add(span.text());
+                    cnt++;
+                } else {
                     break;
                 }
-                cnt++;
             }
             index++;
         }

--- a/backend/src/main/java/com/ziio/backend/entity/Academic.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Academic.java
@@ -12,7 +12,9 @@ public class Academic {
     private Long id;
 
     private String date;
-    private String titleAndHostDepartment;
+    private String title;
+
+    private String host_department;
 
     public Long getId() {
         return id;
@@ -30,11 +32,19 @@ public class Academic {
         this.date = date;
     }
 
-    public String getTitleAndHostDepartment() {
-        return titleAndHostDepartment;
+    public String getTitle() {
+        return title;
     }
 
-    public void setTitleAndHostDepartment(String titleAndHostDepartment) {
-        this.titleAndHostDepartment = titleAndHostDepartment;
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getHost_department() {
+        return host_department;
+    }
+
+    public void setHost_department(String host_department) {
+        this.host_department = host_department;
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #13 
## 구현/변경 사항
- 패키지 이름 crawling => crawler로 변경
- 기존에는 제목과 주관부서를 함께 저장, 둘을 따로 저장하는 것으로 변경
## 스크린샷
### 변경 전
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/ec19859d-01af-489e-aaa8-6dbb895be61f)
### 변경 후
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/1c12bd84-6f4c-437f-8782-685bcb76565a)
