### PR TITLE
[Feat] 구글 OAuth2.0 로그인 기능 구현 및 사용자(user) DB 구축

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.4'
-    id 'io.spring.dependency-management' version '1.1.3'
+    id 'org.springframework.boot' version '2.7.13'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 }
 
 group = 'com.ziio'
@@ -14,23 +14,24 @@ java {
 repositories {
     mavenCentral()
 }
+
 dependencies {
-    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.33'
+    // 웹
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.projectlombok:lombok:1.18.28'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.jsoup:jsoup:1.13.1'
-
+    // 크롤러
+    implementation 'org.jsoup:jsoup:1.15.3'
+    // DB
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.33'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'com.h2database:h2'
-    implementation 'org.springframework.boot:spring-boot-starter'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
-}
-
-
-repositories {
-    mavenCentral()
+    // 구글 로그인
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // 롬복
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }

--- a/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.ziio.backend.config;
+
+import com.ziio.backend.config.handler.OAuthLoginFailureHandler;
+import com.ziio.backend.config.handler.OAuthLoginSuccessHandler;
+import com.ziio.backend.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    @Autowired
+    UserService userService;
+    @Autowired
+    OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    @Autowired
+    OAuthLoginFailureHandler oAuthLoginFailureHandler;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .authorizeRequests()
+                    // 로그인 페이지는 누구나 접근 가능
+                    .antMatchers("/login/**").permitAll()
+                    .anyRequest().authenticated()
+                    .and()
+                // oauth 로그인 설정
+                .oauth2Login()
+                    // loginPage가 따로 없으면, 기본 페이지가 나옴
+                    .userInfoEndpoint()
+                    .userService(userService)
+                    .and()
+                // 성공, 실패 핸들러 등록
+                .successHandler(oAuthLoginSuccessHandler)
+                .failureHandler(oAuthLoginFailureHandler);
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginFailureHandler.java
+++ b/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginFailureHandler.java
@@ -1,0 +1,27 @@
+package com.ziio.backend.config.handler;
+
+import com.ziio.backend.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuthLoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Autowired
+    UserService userService;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("LOGIN FAILED : {}", exception.getMessage());
+
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginSuccessHandler.java
+++ b/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginSuccessHandler.java
@@ -1,0 +1,54 @@
+package com.ziio.backend.config.handler;
+
+import com.ziio.backend.entity.User;
+import com.ziio.backend.repository.UserRepository;
+import com.ziio.backend.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
+        // 토큰에서 email 추출
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+
+        String email = token.getPrincipal().getAttribute("email").toString();
+        String name = token.getPrincipal().getAttribute("name").toString();
+        log.info("LOGIN SUCCESS : EMAIL - {}, NAME - {}", email, name);
+
+        // Email로 기존 유저 & 신규 유저인지 확인
+        // 1. 신규 유저인 경우 저장
+        if (!userService.isUserExistsByEmail(email)) {
+            log.info("{} NOT EXISTS. REGISTER", email);
+            User user = new User();
+            user.setEmail(email);
+            user.setName(name);
+
+            userService.save(user);
+        }
+        // 2. 기존 유저인 경우 id 반환 (추후 추가)
+        else {
+            User existUser = userRepository.findUserByEmail(email);
+            Long id = existUser.getId();
+            log.info("{} EXISTS. ID : {}", email, id);
+        }
+
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
@@ -1,7 +1,6 @@
 package com.ziio.backend.controller;
 
 import com.ziio.backend.crawler.CrawlerManager;
-import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
@@ -14,7 +13,7 @@ public class AcademicController {
         this.crawlerManager = crawlerManager;
     }
 
-    @PostConstruct
+    //@PostConstruct
     public void startCrawling() {
         // 크롤링 실행
         crawlerManager.runAcademicCrawlers();

--- a/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
@@ -1,7 +1,6 @@
 package com.ziio.backend.controller;
 
 import com.ziio.backend.crawler.CrawlerManager;
-import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 
@@ -14,7 +13,7 @@ public class NoticeController {
         this.crawlerManager = crawlerManager;
     }
 
-    @PostConstruct
+    //@PostConstruct
     public void startCrawling() {
         // 크롤링 실행
         crawlerManager.runAllCrawlers();

--- a/backend/src/main/java/com/ziio/backend/controller/UserController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/UserController.java
@@ -1,0 +1,14 @@
+package com.ziio.backend.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class UserController {
+
+    @GetMapping("/")
+    private String loginMainTest() {
+        return "loginMainTest";
+    }
+
+}

--- a/backend/src/main/java/com/ziio/backend/entity/Academic.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Academic.java
@@ -1,9 +1,9 @@
 package com.ziio.backend.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Entity
 public class Academic {

--- a/backend/src/main/java/com/ziio/backend/entity/Category.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Category.java
@@ -1,9 +1,9 @@
 package com.ziio.backend.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Entity
 public class Category {

--- a/backend/src/main/java/com/ziio/backend/entity/Notice.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Notice.java
@@ -1,9 +1,9 @@
 package com.ziio.backend.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Entity
 public class Notice {

--- a/backend/src/main/java/com/ziio/backend/entity/User.java
+++ b/backend/src/main/java/com/ziio/backend/entity/User.java
@@ -1,0 +1,21 @@
+package com.ziio.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Setter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String name;
+}

--- a/backend/src/main/java/com/ziio/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.ziio.backend.repository;
+
+import com.ziio.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findUserByEmail(String email);
+}
+

--- a/backend/src/main/java/com/ziio/backend/service/UserService.java
+++ b/backend/src/main/java/com/ziio/backend/service/UserService.java
@@ -1,0 +1,26 @@
+package com.ziio.backend.service;
+
+import com.ziio.backend.entity.User;
+import com.ziio.backend.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class UserService extends DefaultOAuth2UserService {
+
+    @Autowired
+    UserRepository userRepository;
+
+    // 사용자 저장 또는 업데이트
+    public void save(User user) {
+        userRepository.save(user);
+    }
+
+    // 이메일로 기존에 로그인한 회원인지 찾기
+    public boolean isUserExistsByEmail(String email) {
+        return userRepository.findUserByEmail(email) != null;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,7 +8,6 @@ spring.jpa.properties.hibernate.format_sql=true
 
 spring.security.oauth2.client.registration.google.client-id=993982198891-kr7ss29lghlrr8la87med9tajh8klldt.apps.googleusercontent.com
 spring.security.oauth2.client.registration.google.client-secret=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
-spring.security.oauth2.client.registration.google.scope=profile,email
-spring.security.oauth2.client.registration.google.redirect-uri=https://localhost:8080/login/oauth2/code/google
-spring.security.oauth2.client.provider.google.user-info-uri=https://localhost:8080/login
-spring.security.oauth2.client.provider.google.user-name-attribute=name
+spring.security.oauth2.client.registration.google.scope=openid,profile,email
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v2/userinfo

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -5,3 +5,10 @@ spring.datasource.password=your_password
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
+
+spring.security.oauth2.client.registration.google.client-id=993982198891-kr7ss29lghlrr8la87med9tajh8klldt.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=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
+spring.security.oauth2.client.registration.google.scope=profile,email
+spring.security.oauth2.client.registration.google.redirect-uri=https://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.provider.google.user-info-uri=https://localhost:8080/login
+spring.security.oauth2.client.provider.google.user-name-attribute=name


### PR DESCRIPTION
## 관련 이슈
- #20
- #21 
## 구현/변경 사항
- 스프링 시큐리티 관련 문제로 인해, 스프링 부트 버전 3.14 => 2.7.13으로 변경
- 구글 로그인 기능 구현
## 스크린샷
### 로그인 클릭 페이지
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/6c32d779-ff61-4c37-9492-d87698f52be1)
- URI : http://localhost:8080/login
- 현재는 스프링 시큐리티에서 제공하는 기본 화면
### 로그인 페이지
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/c4c8cabe-08eb-40f3-9908-a6b811e9a82e)
- 사용자가 구글 로그인을 실행
### 신규 유저인 경우 (기존에 로그인한 적 X)
```
2023-11-12 19:57:52.895  INFO 9444 --- [nio-8080-exec-7] c.z.b.c.h.OAuthLoginSuccessHandler       : LOGIN SUCCESS : EMAIL - 2018111366@dgu.ac.kr, NAME - 한상호
2023-11-12 19:57:53.350  INFO 9444 --- [nio-8080-exec-7] c.z.b.c.h.OAuthLoginSuccessHandler       : 2018111366@dgu.ac.kr NOT EXISTS. REGISTER
```
```
Hibernate: 
    insert 
    into
        user
        (email, name) 
    values
        (?, ?)
```
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/7e6b241f-2551-44d6-992e-072920e35415)
- 로그 출력 후 DB에 저장
### 기존 유저인 경우
```
2023-11-12 20:01:02.064  INFO 9444 --- [nio-8080-exec-1] c.z.b.c.h.OAuthLoginSuccessHandler       : LOGIN SUCCESS : EMAIL - 2018111366@dgu.ac.kr, NAME - 한상호
2023-11-12 20:01:02.089  INFO 9444 --- [nio-8080-exec-1] c.z.b.c.h.OAuthLoginSuccessHandler       : 2018111366@dgu.ac.kr EXISTS. ID : 1
```
- DB에서 찾아 `id`를 반환
## ToDo
- 프론트와 연동
