### PR TITLE
[Feat] DB 구축 및 수정 & 학사일정 첫 페이지 API 구현

### DIFF
--- a/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
@@ -24,16 +24,18 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .csrf().disable()
                 .authorizeRequests()
-                    // 로그인 페이지는 누구나 접근 가능
-                    .antMatchers("/login/**").permitAll()
-                    .anyRequest().authenticated()
-                    .and()
+                // 누구나 접근 가능한 엔드포인트
+                .antMatchers("/login/**").permitAll()       // 로그인 페이지
+                .antMatchers("/academics/**").permitAll()   // 학사일정 페이지
+                .antMatchers("/notices/**").permitAll()     // 공지사항 페이지
+                .anyRequest().authenticated()
+                .and()
                 // oauth 로그인 설정
                 .oauth2Login()
-                    // loginPage가 따로 없으면, 기본 페이지가 나옴
-                    .userInfoEndpoint()
-                    .userService(userService)
-                    .and()
+                // loginPage가 따로 없으면, 기본 페이지가 나옴
+                .userInfoEndpoint()
+                .userService(userService)
+                .and()
                 // 성공, 실패 핸들러 등록
                 .successHandler(oAuthLoginSuccessHandler)
                 .failureHandler(oAuthLoginFailureHandler);

--- a/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
@@ -1,7 +1,26 @@
 package com.ziio.backend.controller;
 
-import org.springframework.stereotype.Controller;
+import com.ziio.backend.entity.Academic;
+import com.ziio.backend.service.AcademicService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+import java.util.List;
+
+@RestController
+@RequestMapping("/academics")
 public class AcademicController {
+
+    @Autowired
+    private AcademicService academicService;
+
+    @GetMapping
+    public List<Academic> getAllAcademics() {
+        // 모든 학사 일정을 불러와 반환
+        return academicService.getAllAcademics();
+    }
 }
+
+

--- a/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
@@ -54,8 +54,8 @@ public class AcademicCalendarWebsiteCrawler {
                     date = td.text(); // 기간
                     index++;
                 } else if (index == 1) {
-                    title = td.ownText(); // 제목
-                    host_department = td.select("p").text(); // 주관 부서
+                    title = td.ownText().trim(); // 제목
+                    host_department = td.select("p").text().trim(); // 주관 부서
                     break;
                 }
             }
@@ -71,7 +71,10 @@ public class AcademicCalendarWebsiteCrawler {
             academic.setEnd_date(endDate);
 
             academic.setTitle(title); // 제목
-            academic.setHost_department(host_department); // 주관부서
+            // 제목과 주관부서가 다른 경우 == 주관부서가 있는 경우에만 저장
+            if (!title.equals(host_department)) {
+                academic.setHost_department(host_department); // 주관부서
+            }
             // 색상은 랜덤으로 설정
             String code = colorService.findCodeById(randomUtil.generateRandomNumber());
             academic.setColor_code(code); // 헥스코드로 저장

--- a/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/AcademicCalendarWebsiteCrawler.java
@@ -3,6 +3,8 @@ package com.ziio.backend.crawler;
 
 import com.ziio.backend.entity.Academic;
 import com.ziio.backend.service.AcademicService;
+import com.ziio.backend.service.ColorService;
+import com.ziio.backend.util.RandomUtil;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -16,10 +18,14 @@ import java.io.IOException;
 @Component
 public class AcademicCalendarWebsiteCrawler {
     private final AcademicService academicService;
+    private final ColorService colorService;
+    private final RandomUtil randomUtil;
 
     @Autowired
-    public AcademicCalendarWebsiteCrawler(AcademicService academicService) {
+    public AcademicCalendarWebsiteCrawler(AcademicService academicService, ColorService colorService, RandomUtil randomUtil) {
         this.academicService = academicService;
+        this.colorService = colorService;
+        this.randomUtil = randomUtil;
     }
     // 크롤링 실행
     public void crawl() {
@@ -55,9 +61,21 @@ public class AcademicCalendarWebsiteCrawler {
             }
             // DB 저장 로직
             Academic academic = new Academic();
-            academic.setDate(date);
-            academic.setTitle(title);
-            academic.setHost_department(host_department);
+            // 시작일과 종료일로 구분
+            String[] startAndEndDate = date.split("~");
+
+            String startDate = startAndEndDate[0].trim();
+            // 종료일이 없으면 null 처리
+            String endDate = startAndEndDate.length > 1 ? startAndEndDate[1].trim() : null;
+            academic.setStart_date(startDate);
+            academic.setEnd_date(endDate);
+
+            academic.setTitle(title); // 제목
+            academic.setHost_department(host_department); // 주관부서
+            // 색상은 랜덤으로 설정
+            String code = colorService.findCodeById(randomUtil.generateRandomNumber());
+            academic.setColor_code(code); // 헥스코드로 저장
+
             academicService.save(academic);
         }
     }

--- a/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
@@ -2,7 +2,9 @@ package com.ziio.backend.crawler;
 
 import com.ziio.backend.service.AcademicService;
 import com.ziio.backend.service.CategoryService;
+import com.ziio.backend.service.ColorService;
 import com.ziio.backend.service.NoticeService;
+import com.ziio.backend.util.RandomUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -14,10 +16,11 @@ public class CrawlerManager {
     private final AcademicCalendarWebsiteCrawler academicCalendarWebsiteCrawler;
 
     @Autowired
-    public CrawlerManager(NoticeService noticeService, AcademicService academicService, CategoryService categoryService) {
+    public CrawlerManager(NoticeService noticeService, AcademicService academicService, CategoryService categoryService,
+                          ColorService colorService, RandomUtil randomUtil) {
         this.mainWebsiteCrawler = new MainWebsiteCrawler(noticeService, categoryService);
         this.collegeAndDepartmentWebsiteCrawler = new CollegeAndDepartmentWebsiteCrawler(noticeService, categoryService);
-        this.academicCalendarWebsiteCrawler = new AcademicCalendarWebsiteCrawler(academicService);
+        this.academicCalendarWebsiteCrawler = new AcademicCalendarWebsiteCrawler(academicService, colorService, randomUtil);
         this.etcWebsiteCrawler = new EtcWebsiteCrawler(noticeService, categoryService);
     }
 

--- a/backend/src/main/java/com/ziio/backend/entity/Academic.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Academic.java
@@ -13,12 +13,18 @@ public class Academic {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동 +1
     private Long id;
 
-    @Column(nullable = false)
-    private String date;
+    @Column(nullable = true)
+    private String start_date;
+
+    @Column(nullable = true)
+    private String end_date;
 
     @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)
     private String host_department;
+
+    @Column(nullable = false)
+    private String color_code;
 }

--- a/backend/src/main/java/com/ziio/backend/entity/Academic.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Academic.java
@@ -1,50 +1,24 @@
 package com.ziio.backend.entity;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
+import javax.persistence.*;
+
+@Getter
+@Setter
 @Entity
 public class Academic {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동 +1
     private Long id;
 
+    @Column(nullable = false)
     private String date;
+
+    @Column(nullable = false)
     private String title;
 
+    @Column(nullable = false)
     private String host_department;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public void setDate(String date) {
-        this.date = date;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getHost_department() {
-        return host_department;
-    }
-
-    public void setHost_department(String host_department) {
-        this.host_department = host_department;
-    }
 }

--- a/backend/src/main/java/com/ziio/backend/entity/Academic.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Academic.java
@@ -22,7 +22,7 @@ public class Academic {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String host_department;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/ziio/backend/entity/Bookmark.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Bookmark.java
@@ -1,0 +1,26 @@
+package com.ziio.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Column;
+
+@Getter
+@Setter
+@Entity
+public class Bookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String userEmail;
+
+    @Column(nullable = false)
+    private Long categoryId;
+}

--- a/backend/src/main/java/com/ziio/backend/entity/Category.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Category.java
@@ -1,46 +1,24 @@
 package com.ziio.backend.entity;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
+import javax.persistence.*;
+
+@Getter
+@Setter
 @Entity
 public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동 +1
     private Long id;
 
+    @Column(nullable = false)
     private String category_id;
+
+    @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
     private int top_fixed;
-
-    public Long getId() {
-        return id;
-    }
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getCategory_id() {
-        return category_id;
-    }
-
-    public void setCategory_id(String category_id) {
-        this.category_id = category_id;
-    }
-
-    public String getName() {
-        return name;
-    }
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public int getTop_fixed() {
-        return  top_fixed;
-    }
-    public void setTop_fixed(int top_fixed) {
-        this.top_fixed = top_fixed;
-    }
 }

--- a/backend/src/main/java/com/ziio/backend/entity/Color.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Color.java
@@ -1,0 +1,26 @@
+package com.ziio.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Column;
+
+@Getter
+@Setter
+@Entity
+public class Color {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/backend/src/main/java/com/ziio/backend/entity/Mypage.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Mypage.java
@@ -1,0 +1,37 @@
+package com.ziio.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Column;
+
+@Getter
+@Setter
+@Entity
+public class Mypage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String user_email;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String colorId;
+
+    @Column
+    private String url;
+
+    @Column
+    private String memo;
+
+    @Column
+    private String date;
+}

--- a/backend/src/main/java/com/ziio/backend/entity/Notice.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Notice.java
@@ -1,68 +1,31 @@
 package com.ziio.backend.entity;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
 
+import javax.persistence.*;
+
+@Getter
+@Setter
 @Entity
 public class Notice {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동 +1
     private Long id;
 
+    @Column(nullable = false)
     private String title;
+
+    @Column(nullable = false)
     private String url;
+
+    @Column
     private String date_posted;
+
+    @Column
     private String author;
+
+    @Column(nullable = false)
     private String category_id;
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public String getDate_posted() {
-        return date_posted;
-    }
-
-    public void setDate_posted(String date_posted) {
-        this.date_posted = date_posted;
-    }
-
-    public String getAuthor() {
-        return author;
-    }
-
-    public void setAuthor(String author) {
-        this.author = author;
-    }
-
-    public String getCategory_id() {
-        return category_id;
-    }
-
-    public void setCategory_id(String category_id) {
-        this.category_id = category_id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 }
 

--- a/backend/src/main/java/com/ziio/backend/entity/User.java
+++ b/backend/src/main/java/com/ziio/backend/entity/User.java
@@ -3,10 +3,7 @@ package com.ziio.backend.entity;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -16,6 +13,9 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String email;
+
+    @Column(nullable = false)
     private String name;
 }

--- a/backend/src/main/java/com/ziio/backend/repository/BookmarkRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package com.ziio.backend.repository;
+
+import com.ziio.backend.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/backend/src/main/java/com/ziio/backend/repository/ColorRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/ColorRepository.java
@@ -1,0 +1,7 @@
+package com.ziio.backend.repository;
+
+import com.ziio.backend.entity.Color;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ColorRepository extends JpaRepository<Color, Long> {
+}

--- a/backend/src/main/java/com/ziio/backend/repository/MypageRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/MypageRepository.java
@@ -1,0 +1,7 @@
+package com.ziio.backend.repository;
+
+import com.ziio.backend.entity.Mypage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MypageRepository extends JpaRepository<Mypage, Long> {
+}

--- a/backend/src/main/java/com/ziio/backend/service/AcademicService.java
+++ b/backend/src/main/java/com/ziio/backend/service/AcademicService.java
@@ -5,6 +5,8 @@ import com.ziio.backend.repository.AcademicRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class AcademicService {
     private final AcademicRepository academicRepository;
@@ -17,5 +19,8 @@ public class AcademicService {
     // DB에 공지사항 저장
     public void save(Academic academic) {
         academicRepository.save(academic);
+    }
+    public List<Academic> getAllAcademics() {
+        return academicRepository.findAll();
     }
 }

--- a/backend/src/main/java/com/ziio/backend/service/ColorService.java
+++ b/backend/src/main/java/com/ziio/backend/service/ColorService.java
@@ -1,0 +1,27 @@
+package com.ziio.backend.service;
+
+import com.ziio.backend.entity.Color;
+import com.ziio.backend.repository.ColorRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ColorService {
+    private final ColorRepository colorRepository;
+
+    @Autowired
+    public ColorService(ColorRepository colorRepository) {
+        this.colorRepository = colorRepository;
+    }
+
+    // DB에 공지사항 저장
+    public void save(Color color) {
+        colorRepository.save(color);
+    }
+    public String findCodeById(Long id) {
+        return colorRepository.findById(id)
+                .map(Color::getCode)
+                .orElse(null);
+    }
+
+}

--- a/backend/src/main/java/com/ziio/backend/util/RandomUtil.java
+++ b/backend/src/main/java/com/ziio/backend/util/RandomUtil.java
@@ -1,0 +1,17 @@
+package com.ziio.backend.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Slf4j
+@Component
+public class RandomUtil {
+    private final int RANDOM_RANGE = 9;
+    private final Random random = new Random();
+
+    public Long generateRandomNumber() {
+        return (long)(random.nextInt(RANDOM_RANGE) + 1);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       MYSQL_DATABASE: ziio
       MYSQL_USER: ziio_user
       MYSQL_PASSWORD: ziio1234
+    volumes:
+      - ziio_db_data:/var/lib/mysql
     ports:
       - "3306:3306"
     networks:
@@ -32,3 +34,6 @@ services:
 
 networks:
   app-network:
+
+volumes:
+  ziio_db_data:


### PR DESCRIPTION
## 관련 이슈
- #31 
- #20 
## 구현/변경 사항
### MySQL 볼륨 설정을 통해, 컨테이너를 삭제해도 DB는 남아있도록 설정함
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/e795699b-dc5f-49c9-bcf1-56d255edacf2)
### 로그인, 공지사항, 학사일정 페이지는 누구나 접근 가능하도록 설정
```java
// 누구나 접근 가능한 엔드포인트
                .antMatchers("/login/**").permitAll()       // 로그인 페이지
                .antMatchers("/academics/**").permitAll()   // 학사일정 페이지
                .antMatchers("/notices/**").permitAll()     // 공지사항 페이지
                .anyRequest().authenticated()
```
### 마이페이지, 북마크, 색상 테이블 생성
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/ab31de41-513d-456c-a745-046cf9e7227e)
### 색상 정보 DB 저장
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/9656cf2f-af8f-4150-b403-89e29e6bb873)
### 학사일정 테이블 변경사항
- 색상 랜덤으로 지정하여 헥스코드 저장
- 기간을 시작일과 종료일로 분리
- 제목과 주관부서가 동일하면, 주관부서 null로 처리

![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/577cb29b-2335-431e-8d43-817416bab31e)
### 학사일정 첫 페이지 API 구현
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/d9338ec9-4581-4d54-8ae9-36894d229cf1)
## ToDo
- 특정 학사일정을 마이페이지에 추가하는 API 구현