### PR TITLE
[Feat] 사용자 정보 반환 API 구현

### DIFF
--- a/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/login/**").permitAll()       // 로그인 페이지
                 .antMatchers("/academics/**").permitAll()   // 학사일정 페이지
                 .antMatchers("/notices/**").permitAll()     // 공지사항 페이지
+                .antMatchers("/user/**").permitAll()        // 유저 정보 페이지
                 .anyRequest().authenticated()
                 .and()
                 // oauth 로그인 설정

--- a/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
@@ -3,6 +3,8 @@ package com.ziio.backend.controller;
 import com.ziio.backend.entity.Academic;
 import com.ziio.backend.service.AcademicService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,11 +18,13 @@ public class AcademicController {
     @Autowired
     private AcademicService academicService;
 
+    //
     @GetMapping
-    public List<Academic> getAllAcademics() {
-        // 모든 학사 일정을 불러와 반환
-        return academicService.getAllAcademics();
+    public ResponseEntity<List<Academic>> getAllAcademics() {
+        List<Academic> academics = academicService.getAllAcademics();
+        return new ResponseEntity<>(academics, HttpStatus.OK);
     }
+
 }
 
 

--- a/backend/src/main/java/com/ziio/backend/controller/UserController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/UserController.java
@@ -1,8 +1,39 @@
 package com.ziio.backend.controller;
 
-import org.springframework.stereotype.Controller;
+import com.ziio.backend.dto.UserDTO;
+import com.ziio.backend.service.UserService;
+import com.ziio.backend.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
+@RequestMapping("/user")
 public class UserController {
+    @Autowired
+    private JwtUtil jwtUtil;
+    @Autowired
+    private UserService userService;
+
+    // Jwt 토큰을 받아 특정 유저 정보를 반환하는 메소드
+    @GetMapping
+    public ResponseEntity<UserDTO.Info> getUserDetails(@RequestHeader("Authorization") String authorizationHeader) {
+        // 헤더에서 토큰 추출
+        String jwtToken = jwtUtil.getJwtTokenFromHeader(authorizationHeader);
+        // 유저 이메일
+        final String userEmail = jwtUtil.getEmailFromToken(jwtToken);
+        // 유저 이름
+        final String userName = userService.getUserNameByEmail(userEmail);
+        // 응답 객체 생성
+        UserDTO.Info userinfo = UserDTO.Info.builder()
+                                            .email(userEmail)
+                                            .name(userName)
+                                            .build();
+        // ResponseEntity에 응답 객체를 담아서 반환
+        return ResponseEntity.ok(userinfo);
+    }
 
 }

--- a/backend/src/main/java/com/ziio/backend/dto/UserDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/UserDTO.java
@@ -1,0 +1,16 @@
+package com.ziio.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class UserDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Info {
+        private String email;
+        private String name;
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/service/UserService.java
+++ b/backend/src/main/java/com/ziio/backend/service/UserService.java
@@ -19,8 +19,13 @@ public class UserService extends DefaultOAuth2UserService {
         userRepository.save(user);
     }
 
-    // 이메일로 기존에 로그인한 회원인지 찾기
+    // 이메일로 기존에 로그인한 사용자인지 찾기
     public boolean isUserExistsByEmail(String email) {
         return userRepository.findUserByEmail(email) != null;
+    }
+
+    // 이메일로 사용자를 찾아 이름을 반환
+    public String getUserNameByEmail(String email) {
+        return userRepository.findUserByEmail(email).getName();
     }
 }

--- a/backend/src/main/java/com/ziio/backend/util/JwtUtil.java
+++ b/backend/src/main/java/com/ziio/backend/util/JwtUtil.java
@@ -26,8 +26,8 @@ public class JwtUtil {
                 .compact();
     }
 
-    // Jwt 토큰에서 유저의 E-mail을 반환하는 메소드
-    public String getEmailFromToken(String token, String secretKey) {
+    // Jwt 토큰을 검증하고, 사용자의 E-mail을 반환하는 메소드
+    public String getEmailFromToken(String token) {
         try {
             Jws<Claims> claimsJws = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
             Claims body = claimsJws.getBody();
@@ -37,6 +37,11 @@ public class JwtUtil {
             log.info("Invalid token.");
             return null;
         }
+    }
+
+    // 응답 헤더에서 Jwt 토큰을 반환하는 메소드
+    public String getJwtTokenFromHeader(String authorizationHeader) {
+        return authorizationHeader.substring(7);
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
- #35 
## 구현/변경 사항
- 요청 헤더에 Jwt 토큰을 담아서 보내면, 사용자의 이메일과 이름을 반환하는 기능
## 스크린샷
### 요청 Authorization 헤더 예시
```
Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDE4MTExMzY2QGRndS5hYy5rciIsImV4cCI6MTcwMDY0NDcwNH0.goiiDU6Pxoa46imt9gbRwLoTUcgSHGAHkvWZTjrkhME
```
### Jwt 토큰에 따른 사용자 정보 반환 모습
![image](https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/a6d9da6b-3602-4635-857f-0d93e1d09c95)