### PR TITLE
[Feat] 액세스 토큰 발급 및 반환 기능 구현

### DIFF
--- a/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginSuccessHandler.java
+++ b/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginSuccessHandler.java
@@ -7,7 +7,11 @@ import com.ziio.backend.util.JwtUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -25,41 +29,52 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     UserRepository userRepository;
     @Autowired
     JwtUtil jwtUtil;
+    @Autowired
+    private OAuth2AuthorizedClientService authorizedClientService;
     final String REDIRECT_URI = "http://localhost:3000/login?jwt=";
     final long TOKEN_EXPIRATION_TIME = 3600000; // 1시간 동안 유효한 토큰
 
-
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
-        // 토큰에서 email 추출
         OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
 
+        // 토큰에서 email, name 추출
         String email = token.getPrincipal().getAttribute("email").toString();
         String name = token.getPrincipal().getAttribute("name").toString();
-        log.info("LOGIN SUCCESS : EMAIL - {}, NAME - {}", email, name);
 
-        // Jwt 토큰 발급
-        String jwtToken = jwtUtil.generateToken(email, TOKEN_EXPIRATION_TIME);
+        final Authentication authenticationObject = SecurityContextHolder.getContext().getAuthentication();
+        if (authenticationObject != null) {
+            // OAuth2AuthorizedClientService를 통해 액세스 토큰 가져오기
+            OAuth2AuthorizedClient authorizedClient = authorizedClientService.loadAuthorizedClient(
+                    token.getAuthorizedClientRegistrationId(),
+                    token.getName());
+            OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
 
-        // Email로 기존 사용자 & 신규 사용자인지 확인
-        // 1. 신규 사용자인 경우 저장
-        if (!userService.isUserExistsByEmail(email)) {
-            log.info("{} NOT EXISTS. REGISTER", email);
-            User user = new User();
-            user.setEmail(email);
-            user.setName(name);
+            log.info("LOGIN SUCCESS: EMAIL - {}, NAME - {}, ACCESS TOKEN - {}", email, name, accessToken.getTokenValue());
 
+            // Email로 기존 사용자 & 신규 사용자인지 확인
+            User user = userRepository.findUserByEmail(email);
+            if (user == null) {
+                // 1. 신규 사용자인 경우 저장
+                log.info("{} NOT EXISTS. REGISTER", email);
+                user = new User();
+                user.setEmail(email);
+                user.setName(name);
+            } else {
+                // 2. 기존 사용자인 경우 액세스 토큰 업데이트 및 로그 출력
+                log.info("{} EXISTS. ID : {}", email, user.getId());
+            }
+
+            // 액세스 토큰 업데이트
+            user.setAccessToken(accessToken.getTokenValue());
             userService.save(user);
-        }
-        // 2. 기존 사용자인 경우 log만 출력
-        else {
-            User existUser = userRepository.findUserByEmail(email);
-            Long id = existUser.getId();
-            log.info("{} EXISTS. ID : {}", email, id);
-        }
 
-        // 사용자 리다이렉트 시, uri에 쿼리 파라미터로 jwt 토큰을 함께 보냄
-        String redirectUri = REDIRECT_URI + jwtToken;
-        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+            // Jwt 토큰 발급
+            String jwtToken = jwtUtil.generateToken(email, TOKEN_EXPIRATION_TIME);
+
+            // 사용자 리다이렉트 시, uri에 쿼리 파라미터로 jwt 토큰을 함께 보냄
+            String redirectUri = REDIRECT_URI + jwtToken;
+            getRedirectStrategy().sendRedirect(request, response, redirectUri);
+        }
     }
 }

--- a/backend/src/main/java/com/ziio/backend/controller/UserController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.ziio.backend.controller;
 
 import com.ziio.backend.dto.UserDTO;
+import com.ziio.backend.entity.User;
 import com.ziio.backend.service.UserService;
 import com.ziio.backend.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,12 +26,13 @@ public class UserController {
         String jwtToken = jwtUtil.getJwtTokenFromHeader(authorizationHeader);
         // 유저 이메일
         final String userEmail = jwtUtil.getEmailFromToken(jwtToken);
-        // 유저 이름
-        final String userName = userService.getUserNameByEmail(userEmail);
+        // 유저 정보 객체
+        final User user = userService.getUserInfoByEmail(userEmail);
         // 응답 객체 생성 및 반환
         UserDTO.Info userInfo = UserDTO.Info.builder()
                                             .email(userEmail)
-                                            .name(userName)
+                                            .name(user.getName())
+                                            .accessToken(user.getAccessToken())
                                             .build();
 
         return ResponseEntity.ok(userInfo);

--- a/backend/src/main/java/com/ziio/backend/dto/UserDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/UserDTO.java
@@ -2,6 +2,7 @@ package com.ziio.backend.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 public class UserDTO {
 
@@ -10,5 +11,6 @@ public class UserDTO {
     public static class Info {
         private String email;
         private String name;
+        private OAuth2AccessToken accessToken;
     }
 }

--- a/backend/src/main/java/com/ziio/backend/dto/UserDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/UserDTO.java
@@ -2,7 +2,6 @@ package com.ziio.backend.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 public class UserDTO {
 
@@ -11,6 +10,6 @@ public class UserDTO {
     public static class Info {
         private String email;
         private String name;
-        private OAuth2AccessToken accessToken;
+        private String accessToken;
     }
 }

--- a/backend/src/main/java/com/ziio/backend/entity/User.java
+++ b/backend/src/main/java/com/ziio/backend/entity/User.java
@@ -2,6 +2,7 @@ package com.ziio.backend.entity;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 import javax.persistence.*;
 
@@ -18,4 +19,7 @@ public class User {
 
     @Column(nullable = false)
     private String name;
+    
+    @Column(nullable = false)
+    private OAuth2AccessToken accessToken;
 }

--- a/backend/src/main/java/com/ziio/backend/entity/User.java
+++ b/backend/src/main/java/com/ziio/backend/entity/User.java
@@ -2,7 +2,6 @@ package com.ziio.backend.entity;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
 import javax.persistence.*;
 
@@ -21,5 +20,5 @@ public class User {
     private String name;
     
     @Column(nullable = false)
-    private OAuth2AccessToken accessToken;
+    private String accessToken;
 }

--- a/backend/src/main/java/com/ziio/backend/service/UserService.java
+++ b/backend/src/main/java/com/ziio/backend/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService extends DefaultOAuth2UserService {
     }
 
     // 이메일로 사용자를 찾아 이름을 반환
-    public String getUserNameByEmail(String email) {
-        return userRepository.findUserByEmail(email).getName();
+    public User getUserInfoByEmail(String email) {
+        return userRepository.findUserByEmail(email);
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #21 
## 구현/변경 사항
- 액세스 토큰 발급 및 반환 기능 구현
- `/user` 에서 Get 요청 시, 액세스 토큰도 함께 반환
## 스크린샷
### 로그인 시, 액세스 토큰 발급
<img width="893" alt="1" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/c34722b2-06d7-4822-99ce-f77ccd8e4ced">

### DB에 저장
<img width="515" alt="2" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/d61f85d5-bc77-4215-998b-8fe14eb68c7a">

- 신규 유저일 시, 유저 정보와 함께 저장
- 기존 유저일 시, 액세스 토큰만 업데이트

### Get 요청 시 모습
<img width="633" alt="3" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/8c62c1ca-5736-4872-b7ca-767d9e48ee40">