### PR TITLE
[Feat] 구글 액세스토큰 범위 변경 & 마이페이지에 일정을 등록 or 삭제하는 API 구현

### DIFF
--- a/backend/src/main/java/com/ziio/backend/config/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ziio/backend/config/handler/GlobalExceptionHandler.java
@@ -1,16 +1,20 @@
 package com.ziio.backend.config.handler;
 
 import com.ziio.backend.exception.DuplicateRecordException;
+import com.ziio.backend.exception.NotFoundException;
 import com.ziio.backend.exception.TokenException;
 import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.http.HttpStatus;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     private final TokenException tokenExceptionHandler;
+
     @Autowired
     public GlobalExceptionHandler(TokenException tokenExceptionHandler) {
         this.tokenExceptionHandler = tokenExceptionHandler;
@@ -26,5 +30,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicateRecordException.class)
     public ResponseEntity<String> handleDuplicateRecordException(DuplicateRecordException ex) {
         return ex.toDuplicateRecordResponse();
+    }
+
+    // 데이터가 없을 때의 에러를 다루는 핸들러
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<String> handleNotFoundException(NotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
@@ -1,5 +1,6 @@
 package com.ziio.backend.controller;
 
+import com.ziio.backend.dto.AcademicDTO;
 import com.ziio.backend.dto.MyPageDTO;
 import com.ziio.backend.entity.Academic;
 import com.ziio.backend.service.AcademicService;
@@ -34,7 +35,7 @@ public class AcademicController {
     @PostMapping
     public ResponseEntity<MyPageDTO.Info> addAcademicToMyPage(
             @RequestHeader("Authorization") String authorizationHeader,
-            @RequestBody MyPageDTO.Request request) {
+            @RequestBody AcademicDTO.Request request) {
 
         // 학사일정 정보 가져오기
         Long academicId = request.getAcademic_id();
@@ -49,16 +50,16 @@ public class AcademicController {
 
         // 응답 객체 생성 및 반환
         MyPageDTO.Info myPageInfo = MyPageDTO.Info.builder()
+                .academic_id(academicId)
                 .user_email(userEmail)
                 .start_date(academicInfo.getStart_date())
                 .end_date(academicInfo.getEnd_date())
                 .title(academicInfo.getTitle())
                 .color_code(academicInfo.getColor_code())
-                .academic_id(academicId)
                 .message("successfully created.")
                 .build();
 
-        return ResponseEntity.ok(myPageInfo);
+        return new ResponseEntity<>(myPageInfo, HttpStatus.CREATED);
     }
 }
 

--- a/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/AcademicController.java
@@ -1,7 +1,5 @@
 package com.ziio.backend.controller;
 
-import com.ziio.backend.dto.AcademicDTO;
-import com.ziio.backend.dto.MyPageDTO;
 import com.ziio.backend.entity.Academic;
 import com.ziio.backend.service.AcademicService;
 import com.ziio.backend.service.MyPageService;
@@ -9,7 +7,9 @@ import com.ziio.backend.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -31,7 +31,7 @@ public class AcademicController {
         return new ResponseEntity<>(academics, HttpStatus.OK);
     }
 
-    // 특정 학사일정을 사용자의 마이페이지에 추가하는 메소드
+    /* 특정 학사일정을 사용자의 마이페이지에 추가하는 메소드 (API를 통합하여 사용하지 않음)
     @PostMapping
     public ResponseEntity<MyPageDTO.Info> addAcademicToMyPage(
             @RequestHeader("Authorization") String authorizationHeader,
@@ -61,6 +61,7 @@ public class AcademicController {
 
         return new ResponseEntity<>(myPageInfo, HttpStatus.CREATED);
     }
+     */
 }
 
 

--- a/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
@@ -87,4 +87,27 @@ public class NoticeController {
 
         return new ResponseEntity<>(myPageInfo, HttpStatus.CREATED);
     }
+
+    // 특정 공지사항을 마이페이지에서 삭제하는 메소드
+    @DeleteMapping("/scraps")
+    public ResponseEntity<Map<String, String>> removeNoticeToMyPage(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody NoticeDTO.Request request) {
+
+        // 공지사항 정보 가져오기
+        Long noticeId = request.getNotice_id();
+
+        // 토큰에서 유저 이메일 가져오기
+        String jwtToken = jwtUtil.getJwtTokenFromHeader(authorizationHeader);
+        String userEmail = jwtUtil.getEmailFromToken(jwtToken);
+
+        // 마이페이지에서 삭제
+        myPageService.removeNoticeFromMyPage(noticeId, userEmail);
+
+        // 응답 객체 생성 및 반환
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "successfully removed.");
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 }

--- a/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
@@ -100,15 +100,17 @@ public class NoticeController {
             // 정보 가져오기
             Academic academicInfo = academicService.getAcademicById(academicId);
             // 마이페이지에 추가
-            myPageService.addAcademicToMyPage(academicInfo, userEmail);
+            myPageService.addAcademicToMyPage(academicInfo, request, userEmail);
             // 응답 객체 생성 및 반환
             myPageInfo = MyPageDTO.Info.builder()
+                    .notice_id(null)
                     .academic_id(academicId)
                     .user_email(userEmail)
                     .start_date(academicInfo.getStart_date())
                     .end_date(academicInfo.getEnd_date())
-                    .title(academicInfo.getTitle())
-                    .color_code(academicInfo.getColor_code())
+                    .title(request.getTitle() == null ? academicInfo.getTitle() : request.getTitle())
+                    .color_code(request.getColor_code() == null ? academicInfo.getColor_code() : request.getColor_code())
+                    .memo(request.getMemo())
                     .message("successfully created.")
                     .build();
         }

--- a/backend/src/main/java/com/ziio/backend/dto/AcademicDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/AcademicDTO.java
@@ -1,0 +1,27 @@
+package com.ziio.backend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+public class AcademicDTO {
+    @Getter
+    @Builder
+    public static class Info {
+        private String user_email;
+        private String start_date;
+        private String end_date;
+        private String title;
+        private String color_code;
+        private String url;
+        private String memo;
+        private Long academic_id;
+        private String message;
+    }
+
+    @Getter
+    @Setter
+    public static class Request {
+        private Long academic_id;
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/dto/CategoryDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/CategoryDTO.java
@@ -1,0 +1,14 @@
+package com.ziio.backend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class CategoryDTO {
+    @Getter
+    @Builder
+    public static class Info {
+        private String category_id;
+        private String name;
+        private String top_fixed;
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/dto/MyPageDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/MyPageDTO.java
@@ -2,27 +2,22 @@ package com.ziio.backend.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 public class MyPageDTO {
 
     @Getter
     @Builder
     public static class Info {
+        private Long academic_id;
+        private Long notice_id;
+        private String category_id;
         private String user_email;
         private String start_date;
         private String end_date;
         private String title;
-        private String color_code;
         private String url;
+        private String color_code;
         private String memo;
-        private Long academic_id;
         private String message;
-    }
-
-    @Getter
-    @Setter
-    public static class Request {
-        private Long academic_id;
     }
 }

--- a/backend/src/main/java/com/ziio/backend/dto/MyPageDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/MyPageDTO.java
@@ -8,8 +8,8 @@ public class MyPageDTO {
     @Getter
     @Builder
     public static class Info {
-        private Long academic_id;
         private Long notice_id;
+        private Long academic_id;
         private String category_id;
         private String user_email;
         private String start_date;

--- a/backend/src/main/java/com/ziio/backend/dto/NoticeDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/NoticeDTO.java
@@ -8,6 +8,7 @@ public class NoticeDTO {
     @Setter
     public static class Request {
         private Long notice_id;
+        private Long academic_id;
         private String start_date;
         private String end_date;
         private String color_code;

--- a/backend/src/main/java/com/ziio/backend/dto/NoticeDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/NoticeDTO.java
@@ -9,6 +9,7 @@ public class NoticeDTO {
     public static class Request {
         private Long notice_id;
         private Long academic_id;
+        private String title;
         private String start_date;
         private String end_date;
         private String color_code;

--- a/backend/src/main/java/com/ziio/backend/dto/NoticeDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/NoticeDTO.java
@@ -1,0 +1,16 @@
+package com.ziio.backend.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class NoticeDTO {
+    @Getter
+    @Setter
+    public static class Request {
+        private Long notice_id;
+        private String start_date;
+        private String end_date;
+        private String color_code;
+        private String memo;
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/entity/Academic.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Academic.java
@@ -13,16 +13,16 @@ public class Academic {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동 +1
     private Long id;
 
-    @Column(nullable = true)
+    @Column
     private String start_date;
 
-    @Column(nullable = true)
+    @Column
     private String end_date;
 
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = true)
+    @Column
     private String host_department;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/ziio/backend/entity/MyPage.java
+++ b/backend/src/main/java/com/ziio/backend/entity/MyPage.java
@@ -17,10 +17,16 @@ public class MyPage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column
+    private Long academic_id;
+
+    @Column
+    private Long notice_id;
+
     @Column(nullable = false)
     private String user_email;
 
-    @Column(nullable = false)
+    @Column
     private String start_date;
 
     @Column
@@ -38,6 +44,4 @@ public class MyPage {
     @Column
     private String memo;
 
-    @Column
-    private Long academic_id;
 }

--- a/backend/src/main/java/com/ziio/backend/entity/Notice.java
+++ b/backend/src/main/java/com/ziio/backend/entity/Notice.java
@@ -11,7 +11,10 @@ import javax.persistence.*;
 public class Notice {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동 +1
-    private Long id;
+    private Long notice_id;
+
+    @Column(nullable = false)
+    private String category_id;
 
     @Column(nullable = false)
     private String title;
@@ -25,7 +28,5 @@ public class Notice {
     @Column
     private String author;
 
-    @Column(nullable = false)
-    private String category_id;
 }
 

--- a/backend/src/main/java/com/ziio/backend/exception/NotFoundException.java
+++ b/backend/src/main/java/com/ziio/backend/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.ziio.backend.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}
+

--- a/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
@@ -10,4 +10,8 @@ public interface MyPageRepository extends JpaRepository<MyPage, Long> {
     // 사용자의 이메일과 학사일정 id를 기준으로 개수를 카운트하는 메소드
     @Query("SELECT COUNT(mp) FROM MyPage mp WHERE mp.user_email = :userEmail AND mp.academic_id = :academicId")
     long countByUserEmailAndAcademicId(@Param("userEmail") String userEmail, @Param("academicId") Long academicId);
+
+    // 사용자의 이메일과 공지사항 id를 기준으로 개수를 카운트하는 메소드
+    @Query("SELECT COUNT(mp) FROM MyPage mp WHERE mp.user_email = :userEmail AND mp.notice_id = :noticeId")
+    long countByUserEmailAndNoticeId(@Param("userEmail") String userEmail, @Param("noticeId") Long noticeId);
 }

--- a/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
@@ -14,4 +14,8 @@ public interface MyPageRepository extends JpaRepository<MyPage, Long> {
     // 사용자의 이메일과 공지사항 id를 기준으로 개수를 카운트하는 메소드
     @Query("SELECT COUNT(mp) FROM MyPage mp WHERE mp.user_email = :userEmail AND mp.notice_id = :noticeId")
     long countByUserEmailAndNoticeId(@Param("userEmail") String userEmail, @Param("noticeId") Long noticeId);
+
+    // 사용자의 이메일과 공지사항 id로 찾아 정보를 반환하는 메소드
+    @Query("SELECT mp FROM MyPage mp WHERE mp.user_email = :userEmail AND mp.notice_id = :noticeId")
+    MyPage findByUserEmailAndNoticeId(@Param("userEmail") String userEmail, @Param("noticeId") Long noticeId);
 }

--- a/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
@@ -18,4 +18,8 @@ public interface MyPageRepository extends JpaRepository<MyPage, Long> {
     // 사용자의 이메일과 공지사항 id로 찾아 정보를 반환하는 메소드
     @Query("SELECT mp FROM MyPage mp WHERE mp.user_email = :userEmail AND mp.notice_id = :noticeId")
     MyPage findByUserEmailAndNoticeId(@Param("userEmail") String userEmail, @Param("noticeId") Long noticeId);
+
+    // 사용자의 이메일과 학사일정 id로 찾아 정보를 반환하는 메소드
+    @Query("SELECT mp FROM MyPage mp WHERE mp.user_email = :userEmail AND mp.academic_id = :academicId")
+    MyPage findByUserEmailAndAcademicId(@Param("userEmail") String userEmail, @Param("academicId") Long academicId);
 }

--- a/backend/src/main/java/com/ziio/backend/service/MyPageService.java
+++ b/backend/src/main/java/com/ziio/backend/service/MyPageService.java
@@ -31,6 +31,7 @@ public class MyPageService {
             myPage.setStart_date(academic.getStart_date());
             myPage.setEnd_date(academic.getEnd_date());
             myPage.setTitle(academic.getTitle());
+
             myPage.setColor_code(academic.getColor_code());
             myPage.setAcademic_id(academic.getId());
 
@@ -63,10 +64,11 @@ public class MyPageService {
             throw new DuplicateRecordException("This notice is already added to the MyPage.");
         }
     }
+
     // 마이페이지에서 특정 공지사항을 삭제하는 메소드
     public void removeNoticeFromMyPage(Long noticeId, String userEmail) {
         // 해당 공지사항이 마이페이지에 존재하는지 확인
-        MyPage myPage = myPageRepository.findByUserEmailAndNoticeId(userEmail , noticeId);
+        MyPage myPage = myPageRepository.findByUserEmailAndNoticeId(userEmail, noticeId);
 
         if (myPage != null) {
             // 존재한다면 삭제
@@ -74,6 +76,20 @@ public class MyPageService {
         } else {
             // 존재하지 않는 경우
             throw new NotFoundException("This notice does not exist in the MyPage.");
+        }
+    }
+
+    // 마이페이지에서 특정 학사일정을 삭제하는 메소드
+    public void removeAcademicFromMyPage(Long academicId, String userEmail) {
+        // 해당 공지사항이 마이페이지에 존재하는지 확인
+        MyPage myPage = myPageRepository.findByUserEmailAndAcademicId(userEmail, academicId);
+
+        if (myPage != null) {
+            // 존재한다면 삭제
+            myPageRepository.delete(myPage);
+        } else {
+            // 존재하지 않는 경우
+            throw new NotFoundException("This academic does not exist in the MyPage.");
         }
     }
 }

--- a/backend/src/main/java/com/ziio/backend/service/MyPageService.java
+++ b/backend/src/main/java/com/ziio/backend/service/MyPageService.java
@@ -1,7 +1,9 @@
 package com.ziio.backend.service;
 
+import com.ziio.backend.dto.NoticeDTO;
 import com.ziio.backend.entity.Academic;
 import com.ziio.backend.entity.MyPage;
+import com.ziio.backend.entity.Notice;
 import com.ziio.backend.exception.DuplicateRecordException;
 import com.ziio.backend.repository.MyPageRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +37,29 @@ public class MyPageService {
         } else {
             // 중복인 경우
             throw new DuplicateRecordException("This academic is already added to the MyPage.");
+        }
+    }
+
+    // 마이페이지에 특정 공지사항을 추가하는 메소드
+    public void addNoticeToMyPage(Notice notice, NoticeDTO.Request request, String userEmail) {
+        // 중복 체크
+        long count = myPageRepository.countByUserEmailAndNoticeId(userEmail, request.getNotice_id());
+        // 중복이 아닌 경우
+        if (count == 0) {
+            MyPage myPage = new MyPage();
+            myPage.setNotice_id(notice.getNotice_id());
+            myPage.setUser_email(userEmail);
+            myPage.setStart_date(request.getStart_date());
+            myPage.setEnd_date(request.getEnd_date());
+            myPage.setTitle(notice.getTitle());
+            myPage.setColor_code(request.getColor_code());
+            myPage.setUrl(notice.getUrl());
+            myPage.setMemo(request.getMemo());
+
+            myPageRepository.save(myPage);
+        } else {
+            // 중복인 경우
+            throw new DuplicateRecordException("This notice is already added to the MyPage.");
         }
     }
 }

--- a/backend/src/main/java/com/ziio/backend/service/MyPageService.java
+++ b/backend/src/main/java/com/ziio/backend/service/MyPageService.java
@@ -21,19 +21,19 @@ public class MyPageService {
     }
 
     // 마이페이지에 학사일정을 추가하는 메소드
-    public void addAcademicToMyPage(Academic academic, String userEmail) {
+    public void addAcademicToMyPage(Academic academic, NoticeDTO.Request request, String userEmail) {
         // 중복 체크
         long count = myPageRepository.countByUserEmailAndAcademicId(userEmail, academic.getId());
         // 중복이 아닌 경우
         if (count == 0) {
             MyPage myPage = new MyPage();
+            myPage.setAcademic_id(academic.getId());
             myPage.setUser_email(userEmail);
             myPage.setStart_date(academic.getStart_date());
             myPage.setEnd_date(academic.getEnd_date());
-            myPage.setTitle(academic.getTitle());
-
-            myPage.setColor_code(academic.getColor_code());
-            myPage.setAcademic_id(academic.getId());
+            myPage.setTitle(request.getTitle() == null ? academic.getTitle() : request.getTitle());
+            myPage.setColor_code(request.getColor_code() == null ? academic.getColor_code() : request.getColor_code());
+            myPage.setMemo(request.getMemo());
 
             myPageRepository.save(myPage);
         } else {

--- a/backend/src/main/java/com/ziio/backend/service/MyPageService.java
+++ b/backend/src/main/java/com/ziio/backend/service/MyPageService.java
@@ -5,6 +5,7 @@ import com.ziio.backend.entity.Academic;
 import com.ziio.backend.entity.MyPage;
 import com.ziio.backend.entity.Notice;
 import com.ziio.backend.exception.DuplicateRecordException;
+import com.ziio.backend.exception.NotFoundException;
 import com.ziio.backend.repository.MyPageRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -60,6 +61,19 @@ public class MyPageService {
         } else {
             // 중복인 경우
             throw new DuplicateRecordException("This notice is already added to the MyPage.");
+        }
+    }
+    // 마이페이지에서 특정 공지사항을 삭제하는 메소드
+    public void removeNoticeFromMyPage(Long noticeId, String userEmail) {
+        // 해당 공지사항이 마이페이지에 존재하는지 확인
+        MyPage myPage = myPageRepository.findByUserEmailAndNoticeId(userEmail , noticeId);
+
+        if (myPage != null) {
+            // 존재한다면 삭제
+            myPageRepository.delete(myPage);
+        } else {
+            // 존재하지 않는 경우
+            throw new NotFoundException("This notice does not exist in the MyPage.");
         }
     }
 }

--- a/backend/src/main/java/com/ziio/backend/service/NoticeService.java
+++ b/backend/src/main/java/com/ziio/backend/service/NoticeService.java
@@ -6,6 +6,7 @@ import com.ziio.backend.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,6 +26,12 @@ public class NoticeService {
     // 모든 공지사항 정보를 반환하는 메소드
     public List<Notice> getAllNotices() {
         return noticeRepository.findAll();
+    }
+
+    // 특정 id의 공지사항을 반환하는 메소드
+    public Notice getNoticeById(Long noticeId) {
+        return noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new EntityNotFoundException("Academic not found with id: " + noticeId));
     }
 
     // 부모 카테고리 id와 키워드를 포함하는 공지사항을 찾아 반환하는 메소드

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,8 +15,8 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 server.port=8080
 
 # Spring security
-spring.security.oauth2.client.registration.google.client-id=993982198891-kr7ss29lghlrr8la87med9tajh8klldt.apps.googleusercontent.com
-spring.security.oauth2.client.registration.google.client-secret=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
+spring.security.oauth2.client.registration.google.client-id=910683115043-b1hl3b0imsrcld281csoa8jul64u25u7.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=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
 spring.security.oauth2.client.registration.google.scope=openid,profile,email
 spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
 spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v2/userinfo


### PR DESCRIPTION
## 관련 이슈
- #40 
## 구현/변경 사항
- 도커 볼륨 설정
- 구글 액세스토큰 범위 캘린더까지 속하도록 변경
- 마이페이지에 일정을 등록 or 삭제하는 API 구현
## 스크린샷
## 1. 공지사항
### 마이페이지 등록
<img width="637" alt="2" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/703cbf26-6061-47b8-bb01-49790aca21f7">

### 중복 등록 에러
<img width="512" alt="2_중복에러" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/a6d1295f-1c95-4bd7-ba0d-f8d119ef036c">

### 사용자 요청 데이터 추가
<img width="633" alt="2_데이터추가" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/46b0880c-1f7d-4b75-9ae3-418821c285b9">

### 마이페이지 삭제
<img width="512" alt="2_공지사항삭제" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/e1112bf2-ec23-4d8b-9ed9-ed758400f067">

### 없는 공지사항에 대한 요청 시
<img width="515" alt="2_공지사항없음" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/2c6ab3d4-c6fb-4086-971d-5daf9a739a3d">

## 2. 학사일정

### 마이페이지 등록
<img width="637" alt="3_학사일정" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/56b7387b-a39a-47d7-a108-bb1012d47caa">

### 중복 등록 에러
<img width="510" alt="3_학사일정중복" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/f5aafe48-afea-46a5-b612-28b85b7fbfb0">

### 사용자 요청 데이터 추가
<img width="636" alt="3_학사일정_데이터추가" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/7f2cc4a6-781c-4b24-9642-a1749dc3d01e">

### 마이페이지 삭제
<img width="512" alt="3_학사일정삭제" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/636b1e31-6411-4dee-835d-d89c1c1dd94f">

### 없는 학사일정에 대한 요청 시
<img width="513" alt="3_학사일정없음" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/85f7809a-4551-454c-840d-439ca1c00ef2">

## ToDo
- 즐겨찾기 관련 API 구현
