### PR TITLE
[Feat] 액세스 토큰 scope 수정, 공지사항 관련 변경사항

### DIFF
--- a/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginSuccessHandler.java
+++ b/backend/src/main/java/com/ziio/backend/config/handler/OAuthLoginSuccessHandler.java
@@ -34,6 +34,8 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     final String REDIRECT_URI = "http://localhost:3000/login?jwt=";
     final long TOKEN_EXPIRATION_TIME = 3600000; // 1시간 동안 유효한 토큰
 
+    // 이전 코드 생략
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
         OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;

--- a/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/NoticeController.java
@@ -19,6 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.ziio.backend.constants.CrawlingInfos.MAIN_ALL_INFOS;
+
 @RestController
 @RequestMapping("/notices")
 public class NoticeController {
@@ -34,14 +36,14 @@ public class NoticeController {
     @Autowired
     private JwtUtil jwtUtil ;
 
-    // 모든 공지사항을 반환하는 메소드(= 공지사항 첫 화면)
+    // 모든 일반 공지사항을 반환하는 메소드(= 공지사항 첫 화면)
     @GetMapping
-    public ResponseEntity<Map<String, Object>> getAllNotices() {
-        List<Notice> notices = noticeService.getAllNotices();
+    public ResponseEntity<Map<String, Object>> getGeneralNotices() {
+        List<Notice> generalNotices = noticeService.getNoticesByCategoryIdAndKeyword(MAIN_ALL_INFOS[0][0], null);
         List<Category> categories = categoryService.getAllCategories();
 
         Map<String, Object> response = new HashMap<>();
-        response.put("notices", notices);
+        response.put("notices", generalNotices);
         response.put("categories", categories);
 
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
@@ -1,31 +1,32 @@
 package com.ziio.backend.crawler;
 
-import com.ziio.backend.service.AcademicService;
 import com.ziio.backend.service.CategoryService;
-import com.ziio.backend.service.ColorService;
 import com.ziio.backend.service.NoticeService;
-import com.ziio.backend.util.RandomUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
+
 @Component
 public class CrawlerManager {
-    private final MainWebsiteCrawler mainWebsiteCrawler;
-    private final CollegeAndDepartmentWebsiteCrawler collegeAndDepartmentWebsiteCrawler;
-    private final EtcWebsiteCrawler etcWebsiteCrawler;
-    private final AcademicCalendarWebsiteCrawler academicCalendarWebsiteCrawler;
-
     @Autowired
-    public CrawlerManager(NoticeService noticeService, AcademicService academicService, CategoryService categoryService,
-                          ColorService colorService, RandomUtil randomUtil) {
-        this.mainWebsiteCrawler = new MainWebsiteCrawler(noticeService, categoryService);
-        this.collegeAndDepartmentWebsiteCrawler = new CollegeAndDepartmentWebsiteCrawler(noticeService, categoryService);
-        this.academicCalendarWebsiteCrawler = new AcademicCalendarWebsiteCrawler(academicService, colorService, randomUtil);
-        this.etcWebsiteCrawler = new EtcWebsiteCrawler(noticeService, categoryService);
-    }
+    private MainWebsiteCrawler mainWebsiteCrawler;
+    @Autowired
+    private CollegeAndDepartmentWebsiteCrawler collegeAndDepartmentWebsiteCrawler;
+    @Autowired
+    private EtcWebsiteCrawler etcWebsiteCrawler;
+    @Autowired
+    private AcademicCalendarWebsiteCrawler academicCalendarWebsiteCrawler;
+    @Autowired
+    private CategoryService categoryService;
+    @Autowired
+    private NoticeService noticeService;
 
-    //@PostConstruct
+    @PostConstruct
     public void runAllCrawlers() {
+        // 카테고리와 공지사항 삭제
+        categoryService.deleteAllCategories();
+        noticeService.deleteAllNotices();
         // 각 크롤러 실행
         mainWebsiteCrawler.crawl();
         collegeAndDepartmentWebsiteCrawler.crawl();

--- a/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
+++ b/backend/src/main/java/com/ziio/backend/crawler/CrawlerManager.java
@@ -5,8 +5,6 @@ import com.ziio.backend.service.NoticeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-
 @Component
 public class CrawlerManager {
     @Autowired
@@ -22,7 +20,7 @@ public class CrawlerManager {
     @Autowired
     private NoticeService noticeService;
 
-    @PostConstruct
+    // @PostConstruct
     public void runAllCrawlers() {
         // 카테고리와 공지사항 삭제
         categoryService.deleteAllCategories();

--- a/backend/src/main/java/com/ziio/backend/service/CategoryService.java
+++ b/backend/src/main/java/com/ziio/backend/service/CategoryService.java
@@ -24,5 +24,10 @@ public class CategoryService {
     public List<Category> getAllCategories() {
         return categoryRepository.findAll();
     }
+
+    // 모든 카테고리를 삭제하는 메소드
+    public void deleteAllCategories() {
+        categoryRepository.deleteAll();
+    }
 }
 

--- a/backend/src/main/java/com/ziio/backend/service/NoticeService.java
+++ b/backend/src/main/java/com/ziio/backend/service/NoticeService.java
@@ -56,4 +56,9 @@ public class NoticeService {
                     .collect(Collectors.toList());
         }
     }
+
+    // 모든 공지사항을 삭제하는 메소드
+    public void deleteAllNotices() {
+        noticeRepository.deleteAll();
+    }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,9 +17,9 @@ server.port=8080
 # Spring security
 spring.security.oauth2.client.registration.google.client-id=910683115043-b1hl3b0imsrcld281csoa8jul64u25u7.apps.googleusercontent.com
 spring.security.oauth2.client.registration.google.client-secret=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
-spring.security.oauth2.client.registration.google.scope=openid,profile,email
-spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.scope=openid,profile,email,https://www.googleapis.com/auth/calendar.events
 spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v2/userinfo
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
 
 # Private Keys
 secret.key=7d8ea79968e15c74a8f3c3e03a2b9cc98c62dd205db34c9ee4b151c4d7f2c6e5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,33 @@
 version: '3'
 
 services:
+  ziio_db:
+    image: mysql:8.0.33
+    container_name: ziio_db
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_DATABASE=ziio
+      - MYSQL_ROOT_HOST=%
+      - MYSQL_ROOT_PASSWORD=1234
+    volumes:
+      - ziio_db_data:/var/lib/mysql
+    networks:
+      - app-network
+
   ziio_backend:
     build:
       context: ./backend
       dockerfile: Dockerfile
     container_name: ziio_backend
+    ports:
+      - "8080:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://ziio_db:3306/ziio?useSSL=false&tinyInt1isBit=false&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_USERNAME: ziio_user
       SPRING_DATASOURCE_PASSWORD: ziio1234
-    ports:
-      - "8080:8080"
-    networks:
-      - app-network
     depends_on:
       - ziio_db
-
-  ziio_db:
-    image: mysql:8.0.33
-    container_name: ziio_db
-    environment:
-      MYSQL_ROOT_PASSWORD: 1234
-      MYSQL_DATABASE: ziio
-      MYSQL_USER: ziio_user
-      MYSQL_PASSWORD: ziio1234
-    volumes:
-      - ziio_db_data:/var/lib/mysql
-    ports:
-      - "3306:3306"
     networks:
       - app-network
 


### PR DESCRIPTION
## 관련 이슈
- #46 
## 구현/변경 사항
- 구글 캘린더도 사용 가능한 액세스 토큰을 얻어오도록 변경
-  `/notices` GET시 (공지사항 첫 화면), 일반 공지만 반환
- 공지사항 크롤링 시작 전, `notice` , `category` 테이블 초기화