### PR TITLE
[Feat] 마이페이지 API 구현

### DIFF
--- a/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ziio/backend/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/academics/**").permitAll()
                 .antMatchers("/notices/**").permitAll()
                 .antMatchers("/bookmarks/**").permitAll()
+                .antMatchers("/mypages/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 // 구글 OAuth 2.0 로그인 관련 설정

--- a/backend/src/main/java/com/ziio/backend/controller/MyPageController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/MyPageController.java
@@ -1,0 +1,39 @@
+package com.ziio.backend.controller;
+
+import com.ziio.backend.entity.MyPage;
+import com.ziio.backend.service.MyPageService;
+import com.ziio.backend.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/mypages")
+public class MyPageController {
+
+    @Autowired
+    private MyPageService myPageService;
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    // 사용자의 모든 마이페이지 일정을 반환하는 메소드(= 마이페이지 첫 화면)
+    @GetMapping
+    public ResponseEntity<List<MyPage>> getAllMyPages(
+            @RequestHeader("Authorization") String authorizationHeader) {
+
+        // 토큰에서 유저 이메일 가져오기
+        String jwtToken = jwtUtil.getJwtTokenFromHeader(authorizationHeader);
+        String userEmail = jwtUtil.getEmailFromToken(jwtToken);
+
+        List<MyPage> myPages = myPageService.getAllMyPagesByUserEmail(userEmail);
+
+        return new ResponseEntity<>(myPages, HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/ziio/backend/controller/MyPageController.java
+++ b/backend/src/main/java/com/ziio/backend/controller/MyPageController.java
@@ -1,15 +1,13 @@
 package com.ziio.backend.controller;
 
+import com.ziio.backend.dto.MyPageDTO;
 import com.ziio.backend.entity.MyPage;
 import com.ziio.backend.service.MyPageService;
 import com.ziio.backend.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -35,5 +33,43 @@ public class MyPageController {
         List<MyPage> myPages = myPageService.getAllMyPagesByUserEmail(userEmail);
 
         return new ResponseEntity<>(myPages, HttpStatus.OK);
+    }
+
+    // 사용자의 요청에 따라 일정을 수정하는 메소드
+    @PatchMapping
+    public ResponseEntity<MyPageDTO.Info> updateMyPage(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody MyPageDTO.Request request) {
+
+        // 토큰에서 유저 이메일 가져오기
+        String jwtToken = jwtUtil.getJwtTokenFromHeader(authorizationHeader);
+        String userEmail = jwtUtil.getEmailFromToken(jwtToken);
+
+        // 마이페이지 id는 필수값
+        if (request.getMy_page_id() == null) {
+            throw new IllegalArgumentException("MyPage ID cannot be null.");
+        }
+        Long myPageId = request.getMy_page_id();
+
+        // 마이페이지 일정 업데이트
+        MyPage updatedMyPage = myPageService.updateMyPage(myPageId, request, userEmail);
+
+        // 응답 객체 생성 및 반환
+        MyPageDTO.Info updatedMyPageResponse = MyPageDTO.Info.builder()
+                .my_page_id(myPageId)
+                .notice_id(updatedMyPage.getNotice_id())
+                .academic_id(updatedMyPage.getAcademic_id())
+                .category_id(updatedMyPage.getCategory_id())
+                .user_email(updatedMyPage.getUser_email())
+                .start_date(updatedMyPage.getStart_date())
+                .end_date(updatedMyPage.getEnd_date())
+                .title(updatedMyPage.getTitle())
+                .url(updatedMyPage.getUrl())
+                .color_code(updatedMyPage.getColor_code())
+                .memo(updatedMyPage.getMemo())
+                .message("successfully updated.")
+                .build();
+
+        return new ResponseEntity<>(updatedMyPageResponse, HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/com/ziio/backend/dto/MyPageDTO.java
+++ b/backend/src/main/java/com/ziio/backend/dto/MyPageDTO.java
@@ -2,12 +2,14 @@ package com.ziio.backend.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 public class MyPageDTO {
 
     @Getter
     @Builder
     public static class Info {
+        private Long my_page_id;
         private String notice_id;
         private Long academic_id;
         private String category_id;
@@ -19,5 +21,16 @@ public class MyPageDTO {
         private String color_code;
         private String memo;
         private String message;
+    }
+    @Getter
+    @Setter
+    public static class Request {
+        private Long my_page_id;
+        private String start_date;
+        private String end_date;
+        private String title;
+        private String url;
+        private String color_code;
+        private String memo;
     }
 }

--- a/backend/src/main/java/com/ziio/backend/entity/MyPage.java
+++ b/backend/src/main/java/com/ziio/backend/entity/MyPage.java
@@ -15,7 +15,7 @@ import javax.persistence.Column;
 public class MyPage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long my_page_id;
 
     @Column
     private Long academic_id;

--- a/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
+++ b/backend/src/main/java/com/ziio/backend/repository/MyPageRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface MyPageRepository extends JpaRepository<MyPage, Long> {
 
     // 사용자의 이메일과 학사일정 id를 기준으로 개수를 카운트하는 메소드
@@ -22,4 +24,8 @@ public interface MyPageRepository extends JpaRepository<MyPage, Long> {
     // 사용자의 이메일과 학사일정 id로 찾아 정보를 반환하는 메소드
     @Query("SELECT mp FROM MyPage mp WHERE mp.user_email = :userEmail AND mp.academic_id = :academicId")
     MyPage findByUserEmailAndAcademicId(@Param("userEmail") String userEmail, @Param("academicId") Long academicId);
+
+    // 사용자의 이메일에 해당하는 모든 마이페이지 정보 반환
+    @Query("SELECT mp FROM MyPage mp WHERE mp.user_email = :userEmail")
+    List<MyPage> findByUserEmail(@Param("userEmail") String userEmail);
 }

--- a/backend/src/main/java/com/ziio/backend/service/MyPageService.java
+++ b/backend/src/main/java/com/ziio/backend/service/MyPageService.java
@@ -1,5 +1,6 @@
 package com.ziio.backend.service;
 
+import com.ziio.backend.dto.MyPageDTO;
 import com.ziio.backend.dto.NoticeDTO;
 import com.ziio.backend.entity.Academic;
 import com.ziio.backend.entity.MyPage;
@@ -103,6 +104,39 @@ public class MyPageService {
     // 특정 사용자의 마이페이지를 모두 반환하는 메소드
     public List<MyPage> getAllMyPagesByUserEmail(String userEmail) {
         return myPageRepository.findByUserEmail(userEmail);
+    }
+
+    // 특정 사용자의 마이페이지를 업데이트하는 메소드
+    public MyPage updateMyPage(Long myPageId, MyPageDTO.Request request, String userEmail) {
+        // 업데이트할 마이페이지 찾기
+        MyPage myPage = myPageRepository.findById(myPageId)
+                .orElseThrow(() -> new NotFoundException("MyPage not found with ID: " + myPageId));
+
+        // 사용자가 해당 마이페이지를 소유하고 있는지 확인
+        if (!myPage.getUser_email().equals(userEmail)) {
+            throw new NotFoundException("MyPage not found for the user with ID: " + myPageId);
+        }
+
+        // 업데이트할 필드 설정
+        if (request.getTitle() != null) {
+            myPage.setTitle(request.getTitle());
+        }
+        if (request.getStart_date() != null) {
+            myPage.setStart_date(request.getStart_date());
+        }
+        if (request.getEnd_date() != null) {
+            myPage.setEnd_date(request.getEnd_date());
+        }
+        if (request.getColor_code() != null) {
+            myPage.setColor_code(request.getColor_code());
+        }
+        if (request.getMemo() != null) {
+            myPage.setMemo(request.getMemo());
+        }
+
+        myPageRepository.save(myPage);
+
+        return myPage;
     }
 }
 

--- a/backend/src/main/java/com/ziio/backend/service/MyPageService.java
+++ b/backend/src/main/java/com/ziio/backend/service/MyPageService.java
@@ -10,6 +10,8 @@ import com.ziio.backend.repository.MyPageRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class MyPageService {
 
@@ -96,6 +98,11 @@ public class MyPageService {
             // 존재하지 않는 경우
             throw new NotFoundException("This academic does not exist in the MyPage.");
         }
+    }
+
+    // 특정 사용자의 마이페이지를 모두 반환하는 메소드
+    public List<MyPage> getAllMyPagesByUserEmail(String userEmail) {
+        return myPageRepository.findByUserEmail(userEmail);
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
- #45 
## 구현/변경 사항
- 마이페이지 첫 화면 API 구현
- 특정 일정 정보 수정 API 구현
## 스크린샷
### 마이페이지 첫 화면
<img width="515" alt="1_마이페이지첫화면성공" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/0fc60a52-aa0f-42bc-b51a-d264fe282c49">

- `Jwt 토큰`으로 사용자를 인식, 관련된 일정들만 반환
### 마이페이지 테이블 모습
<img width="901" alt="2_디비저장모습" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/6dacded8-3c1c-4f7e-8875-467483b8f426">

### 특정 사용자의 일정 정보 수정
<img width="516" alt="3_패치성공모습" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/524ea532-74a7-4778-8016-b695681b41d6">

- `Jwt 토큰`과 `my_page_id`는 필수값
### DB도 요청에 맞게 변경된 모습
<img width="434" alt="3_패치디비변경모습" src="https://github.com/CSID-DGU/2023-2-OSSProj-ZIIO-4/assets/113084292/7bc8666b-52f3-4892-9ecc-c8b05bea5d3f">

## ToDo
- `정보 수정 시, null 값을 어떻게 처리할 것인지?` : 추후 결정 후 반영
