### PR TITLE
[feat] 공지사항, 학사일정 백엔드 오류 수정

### DIFF
--- a/frontend/src/components/ClipModal/ClipModal.jsx
+++ b/frontend/src/components/ClipModal/ClipModal.jsx
@@ -20,11 +20,10 @@ const ClipModal = ({ noticeId, categoryId, onModalClose, openEventModal }) => {
       category_id: categoryId
     }
 
-    console.log(resultData);
     const SearchData = fetchProjects(resultData);
     try {
       const result = await SearchData;
-      console.log(result);
+      if (result) onModalClose(false);
     } catch (error) {
       console.error('Error:', error);
     }

--- a/frontend/src/pages/MainNotice/MainNotice.jsx
+++ b/frontend/src/pages/MainNotice/MainNotice.jsx
@@ -30,10 +30,11 @@ const fetchProjects = async (type, value1, value2) => {
       response = await instance.get('/scraps');
       return response.data;
     case "addEventsScraps":
+      console.log(value1);
       response = await instance.post(`/scraps`, value1);
       return response.data;
     case "deleteScraps":
-      response = await instance.delete(`/notices/scraps`, value1);
+      response = await instance.delete(`/scraps`, value1);
       return response.data;
     default:
       response = await instance.get('/notices');
@@ -167,6 +168,14 @@ function MainNotice() {
       }
     }
   }, [data]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      const scrapsData = getScraps();
+      const formattedNotices = noticeFormat(noticeList, scrapsData);
+      setNoticeList(formattedNotices);
+    }
+  }, [isOpen]);
 
   const noticeFormat = (data, scraps) => {
     const newArray = data;
@@ -326,9 +335,6 @@ function MainNotice() {
         const result = deleteScraps({ notice_id: item.value.notice_id, category_id: item.value.category_id })
         if (result === "success") alert("스크랩이 취소되었습니다")
       }
-      const scrapsData = getScraps();
-      const formattedNotices = noticeFormat(noticeList, scrapsData);
-      setNoticeList(formattedNotices);
     }
   }
 
@@ -344,7 +350,7 @@ function MainNotice() {
       notice_id: eventData.id,
       category_id: selectedCategory,
       title: eventData.title,
-      memo: eventData.extendedProps.memo,
+      memo: eventData.extendedProps.memo === undefined ? null : eventData.extendedProps.memo,
       url: eventData.url,
       color_code: eventData.backgroundColor,
     }

--- a/frontend/src/pages/MainNotice/MainNotice.jsx
+++ b/frontend/src/pages/MainNotice/MainNotice.jsx
@@ -31,7 +31,7 @@ const fetchProjects = async (type, value1, value2) => {
       return response.data;
     case "addEventsScraps":
       console.log(value1);
-      response = await instance.post(`/mypages`, value1);
+      response = await instance.post(`/scraps`, value1);
       return response.data;
     case "deleteScraps":
       response = await instance.delete(`/scraps`, value1);

--- a/frontend/src/pages/MainNotice/MainNotice.jsx
+++ b/frontend/src/pages/MainNotice/MainNotice.jsx
@@ -31,7 +31,7 @@ const fetchProjects = async (type, value1, value2) => {
       return response.data;
     case "addEventsScraps":
       console.log(value1);
-      response = await instance.post(`/scraps`, value1);
+      response = await instance.post(`/mypages`, value1);
       return response.data;
     case "deleteScraps":
       response = await instance.delete(`/scraps`, value1);

--- a/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
+++ b/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
@@ -15,13 +15,13 @@ const fetchProjects = async (planData) => {
     const { data } = await instance.get('/academics');
     return data;
   } else {
-    const { data } = await instance.post('/notice/scraps', planData);
+    const { data } = await instance.post('/scraps', planData);
     return data;
   }
 }
 
 function formatDate(dateString) {
-  const parsedDate = new Date(dateString.replace(/\./g, '-'));
+  const parsedDate = new Date(dateString);
   const formattedDate = `${parsedDate.getFullYear()}-${padZero(parsedDate.getMonth() + 1)}-${padZero(parsedDate.getDate())}`;
   return formattedDate;
 }
@@ -47,7 +47,6 @@ const SchoolCalendar = () => {
   useEffect(() => {
     if (data) {
       const transformedEvents = data.map(item => {
-        console.log(item);
         const start = formatDate(item.start_date);
         const end = formatDate(item.end_date);
         return {
@@ -127,7 +126,7 @@ const SchoolCalendar = () => {
   return (
     <div className={styles.container}>
       <div className={styles.leftWrapper}>
-        <div>앞으로의 학사일정 목록</div>
+        <div className={styles.text1}>다음 학사일정 목록</div>
         <EventList listedEvents={listedEvents} handleEventClick={handleEventClick} />
         <EventDetail
           eventTitle={eventTitle}

--- a/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
+++ b/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
@@ -15,7 +15,7 @@ const fetchProjects = async (planData) => {
     const { data } = await instance.get('/academics');
     return data;
   } else {
-    const { data } = await instance.post('/mypages', planData);
+    const { data } = await instance.post('/scraps', planData);
     return data;
   }
 }

--- a/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
+++ b/frontend/src/pages/SchoolCalendar/SchoolCalendar.jsx
@@ -15,7 +15,7 @@ const fetchProjects = async (planData) => {
     const { data } = await instance.get('/academics');
     return data;
   } else {
-    const { data } = await instance.post('/scraps', planData);
+    const { data } = await instance.post('/mypages', planData);
     return data;
   }
 }

--- a/frontend/src/pages/SchoolCalendar/SchoolCalendar.module.scss
+++ b/frontend/src/pages/SchoolCalendar/SchoolCalendar.module.scss
@@ -19,11 +19,18 @@
   height: 100%;
 }
 
+.text1 {
+  margin-top: 1rem;
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: var(--gray-600);
+}
+
 .eventList {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin-top: 5.1rem;
+  margin-top: 1.5rem;
   flex-grow: 1;
   overflow-y: auto;
 
@@ -55,11 +62,15 @@
 }
 
 .eventText {
+  width: 70%;
   color: var(--gray-800, #1f2937);
   font-family: Noto Sans KR;
   font-size: 1.5rem;
   font-style: normal;
   font-weight: 400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   cursor: pointer;
 }
 

--- a/frontend/src/pages/SchoolCalendar/components/EventList.jsx
+++ b/frontend/src/pages/SchoolCalendar/components/EventList.jsx
@@ -11,7 +11,7 @@ const EventList = ({ listedEvents, handleEventClick }) => {
           <div key={event.defId} className={styles.eventListRow} onClick={() => handleEventClick(event)}>
             <div className={styles.eventColor} style={{ backgroundColor: event.color_code }}></div>
             <div className={styles.eventText}>{event.title}</div>
-            <div className={styles.eventDday}>{calculateDDay(event.end_date !== "" ? event.end_date : event.start_date)}</div>
+            <div className={styles.eventDday}>{calculateDDay(event.end_date !== null ? event.end_date : event.start_date)}</div>
           </div>
         )
       ))}


### PR DESCRIPTION
## 관련 이슈
- #17
- #47 

## 구현/변경 사항
- 학사일정 불러오기 오류: date형을 다르게 받아오고 있었음( '-' -> ' . ' ) 
- 다음 학사일정 목록에서 지난 일정 + day로 나오는 오류 수정: end_date !== null 조건문 추가
- 스크랩 시 창 닫기 기능 추가
- 스크랩 삭제 api URL 수정( '/notice/scraps' -> '/scraps' )